### PR TITLE
fix: 리뷰 작성 시 타임존 불일치 및 관련 버그 수정

### DIFF
--- a/backend/app/api/reviews.py
+++ b/backend/app/api/reviews.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import String, cast, func, or_, select
@@ -35,7 +35,7 @@ async def create_review(
     return {**ReviewResponse.model_validate(review).model_dump(), "total_reviews": total}
 
 
-@router.post("/with-book", response_model=ReviewDetailResponse, status_code=201)
+@router.post("/with-book", status_code=201)
 async def create_review_with_book(
     data: ReviewCreateWithBook,
     db: AsyncSession = Depends(get_db),
@@ -153,7 +153,7 @@ async def update_review(
         raise HTTPException(status_code=404, detail="리뷰를 찾을 수 없습니다")
     for key, value in data.model_dump(exclude_unset=True).items():
         setattr(review, key, value)
-    review.updated_at = datetime.now()
+    review.updated_at = datetime.now(UTC)
     await db.commit()
     await db.refresh(review)
     return review
@@ -170,5 +170,5 @@ async def delete_review(
     if not review:
         raise HTTPException(status_code=404, detail="리뷰를 찾을 수 없습니다")
     review.is_deleted = True
-    review.deleted_at = datetime.now()
+    review.deleted_at = datetime.now(UTC)
     await db.commit()

--- a/backend/app/schemas/review.py
+++ b/backend/app/schemas/review.py
@@ -1,8 +1,11 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from pydantic import BaseModel, Field, field_validator
 
 from app.schemas.book import BookResponse, StrId
+
+# KST(UTC+9) 타임존 버퍼: 서버가 UTC로 동작해도 KST 기준 "오늘"을 허용
+_TIMEZONE_BUFFER = timedelta(days=1)
 
 
 class ReviewBase(BaseModel):
@@ -15,7 +18,7 @@ class ReviewBase(BaseModel):
     @field_validator("read_date")
     @classmethod
     def read_date_not_future(cls, v: date) -> date:
-        if v > date.today():
+        if v > date.today() + _TIMEZONE_BUFFER:
             raise ValueError("읽은 날짜는 미래일 수 없습니다")
         return v
 
@@ -43,7 +46,7 @@ class ReviewUpdate(BaseModel):
     @field_validator("read_date")
     @classmethod
     def read_date_not_future(cls, v: date | None) -> date | None:
-        if v and v > date.today():
+        if v and v > date.today() + _TIMEZONE_BUFFER:
             raise ValueError("읽은 날짜는 미래일 수 없습니다")
         return v
 

--- a/backend/tests/test_api_reviews.py
+++ b/backend/tests/test_api_reviews.py
@@ -1,20 +1,31 @@
 async def test_create_review(client):
     book = await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
     book_id = book.json()["id"]
-    resp = await client.post("/api/reviews", json={
-        "book_id": book_id, "read_date": "2026-02-15",
-        "memo": "따뜻한 이야기",
-    })
+    resp = await client.post(
+        "/api/reviews",
+        json={
+            "book_id": book_id,
+            "read_date": "2026-02-15",
+            "memo": "따뜻한 이야기",
+        },
+    )
     assert resp.status_code == 201
     assert resp.json()["book_id"] == book_id
 
+
 async def test_create_review_with_book(client):
-    resp = await client.post("/api/reviews/with-book", json={
-        "title": "곰 사냥을 떠나자", "author": "마이클 로젠",
-        "read_date": "2026-02-14", "memo": "반복되는 문장이 재밌어요",
-    })
+    resp = await client.post(
+        "/api/reviews/with-book",
+        json={
+            "title": "곰 사냥을 떠나자",
+            "author": "마이클 로젠",
+            "read_date": "2026-02-14",
+            "memo": "반복되는 문장이 재밌어요",
+        },
+    )
     assert resp.status_code == 201
     assert resp.json()["book"]["title"] == "곰 사냥을 떠나자"
+
 
 async def test_list_reviews(client):
     book = await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
@@ -26,6 +37,7 @@ async def test_list_reviews(client):
     assert resp.json()["total"] == 2
     assert len(resp.json()["items"]) == 2
 
+
 async def test_update_review(client):
     book = await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
     book_id = book.json()["id"]
@@ -34,6 +46,7 @@ async def test_update_review(client):
     resp = await client.put(f"/api/reviews/{review_id}", json={"memo": "정말 좋아요!"})
     assert resp.status_code == 200
     assert resp.json()["memo"] == "정말 좋아요!"
+
 
 async def test_delete_review(client):
     book = await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
@@ -61,3 +74,73 @@ async def test_get_review(client):
 async def test_get_review_not_found(client):
     resp = await client.get("/api/reviews/99999")
     assert resp.status_code == 404
+
+
+async def test_read_date_kst_today_accepted(client):
+    """KST 기준 오늘(=UTC 기준 내일)도 타임존 버퍼로 허용되어야 한다."""
+    from datetime import date, timedelta
+
+    # UTC 기준 "내일" = KST 자정~08:59에 오늘로 보이는 날짜
+    tomorrow = date.today() + timedelta(days=1)
+
+    book = await client.post("/api/books", json={"title": "시간 테스트", "author": "테스트"})
+    book_id = book.json()["id"]
+    resp = await client.post(
+        "/api/reviews",
+        json={
+            "book_id": book_id,
+            "read_date": tomorrow.isoformat(),
+            "memo": "KST 자정 테스트",
+        },
+    )
+    assert resp.status_code == 201
+
+
+async def test_read_date_future_rejected(client):
+    """확실히 미래인 날짜는 거부되어야 한다."""
+    from datetime import date, timedelta
+
+    future_date = date.today() + timedelta(days=30)
+    book = await client.post("/api/books", json={"title": "미래 테스트", "author": "테스트"})
+    book_id = book.json()["id"]
+    resp = await client.post(
+        "/api/reviews",
+        json={
+            "book_id": book_id,
+            "read_date": future_date.isoformat(),
+            "memo": "미래 날짜",
+        },
+    )
+    assert resp.status_code == 422
+
+
+async def test_create_review_with_book_returns_total_reviews(client):
+    """POST /with-book 응답에 total_reviews가 포함되어야 한다."""
+    resp = await client.post(
+        "/api/reviews/with-book",
+        json={
+            "title": "토탈 테스트",
+            "author": "테스트 작가",
+            "read_date": "2026-02-14",
+            "memo": "메모",
+        },
+    )
+    assert resp.status_code == 201
+    assert "total_reviews" in resp.json()
+    assert resp.json()["total_reviews"] >= 1
+
+
+async def test_create_review_with_book_tags(client):
+    """ReviewCreateWithBook으로 tags를 전달할 수 있어야 한다."""
+    resp = await client.post(
+        "/api/reviews/with-book",
+        json={
+            "title": "태그 테스트",
+            "author": "테스트 작가",
+            "read_date": "2026-02-14",
+            "memo": "메모",
+            "tags": ["그림책", "잠자리"],
+        },
+    )
+    assert resp.status_code == 201
+    assert resp.json()["tags"] == ["그림책", "잠자리"]

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -64,5 +64,6 @@ export interface ReviewCreateWithBook {
   read_date: string;
   memo: string;
   activity: string;
+  tags?: string[];
   child_age_months?: number | null;
 }


### PR DESCRIPTION
## Summary
- read_date 미래 날짜 검증에 KST 타임존 버퍼(1일) 적용 — UTC 서버에서 KST 자정~08:59 시간대 422 에러 해소
- `POST /api/reviews/with-book` 응답에서 `total_reviews`가 `response_model`에 의해 누락되던 문제 수정
- 프론트엔드 `ReviewCreateWithBook` 타입에 `tags` 필드 추가
- `updated_at`/`deleted_at`에 UTC 타임존 명시 (`datetime.now()` → `datetime.now(UTC)`)

## Test plan
- [x] KST 기준 오늘(=UTC 기준 내일) 날짜 허용 테스트
- [x] 확실한 미래 날짜(+30일) 거부 테스트
- [x] `/with-book` 응답에 `total_reviews` 포함 확인
- [x] `tags` 필드 전달 테스트
- [x] 기존 43개 테스트 전체 통과

close #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)