### PR TITLE
fix: 백엔드 보안 취약점 일괄 수정

### DIFF
--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import CurrentUser, get_current_user
 from app.core.database import get_db
 from app.core.tsid import generate_tsid
+from app.core.utils import escape_like
 from app.models.book import Book
 from app.models.review import Review
 from app.schemas.book import BookCreate, BookResponse, BookUpdate, PaginatedBooks
@@ -58,12 +59,12 @@ async def list_books(
     )
     base = select(Book, review_count.label("review_count")).where(Book.is_deleted.is_(False), Book.user_id == user_id)
     if q:
-        base = base.where(or_(Book.title.ilike(f"%{q}%"), Book.author.ilike(f"%{q}%")))
+        base = base.where(or_(Book.title.ilike(f"%{escape_like(q)}%", escape="\\"), Book.author.ilike(f"%{escape_like(q)}%", escape="\\")))
 
     # total count
     count_query = select(Book.id).where(Book.is_deleted.is_(False), Book.user_id == user_id)
     if q:
-        count_query = count_query.where(or_(Book.title.ilike(f"%{q}%"), Book.author.ilike(f"%{q}%")))
+        count_query = count_query.where(or_(Book.title.ilike(f"%{escape_like(q)}%", escape="\\"), Book.author.ilike(f"%{escape_like(q)}%", escape="\\")))
     count_stmt = select(func.count()).select_from(count_query.subquery())
     total = (await db.execute(count_stmt)).scalar() or 0
 

--- a/backend/app/api/reviews.py
+++ b/backend/app/api/reviews.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.auth import CurrentUser, get_current_user
 from app.core.database import get_db
 from app.core.tsid import generate_tsid
+from app.core.utils import escape_like
 from app.models.book import Book
 from app.models.review import Review
 from app.schemas.book import BookResponse
@@ -98,7 +99,7 @@ async def list_reviews(
 ):
     base = select(Review, Book).join(Book, Review.book_id == Book.id).where(Review.is_deleted.is_(False), Review.user_id == user.id)
     if q:
-        base = base.where(or_(Book.title.ilike(f"%{q}%"), Book.author.ilike(f"%{q}%")))
+        base = base.where(or_(Book.title.ilike(f"%{escape_like(q)}%", escape="\\"), Book.author.ilike(f"%{escape_like(q)}%", escape="\\")))
     if language:
         base = base.where(Book.language == language)
     if favorite is not None:
@@ -108,7 +109,7 @@ async def list_reviews(
     if date_to:
         base = base.where(Review.read_date <= date_to)
     if tag:
-        base = base.where(cast(Review.tags, String).ilike(f'%"{tag}"%'))
+        base = base.where(cast(Review.tags, String).ilike(f'%"{escape_like(tag)}"%', escape="\\"))
 
     total = (await db.execute(select(func.count()).select_from(base.subquery()))).scalar() or 0
     stmt = base.order_by(Review.read_date.desc(), Review.id.desc()).offset((page - 1) * size).limit(size)

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.auth import CurrentUser, get_current_user
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.book import Book
@@ -34,6 +35,7 @@ def _detect_language(text: str) -> str:
 async def search_books(
     q: str = Query(..., min_length=1),
     language: str | None = Query(None),
+    user: CurrentUser = Depends(get_current_user),
 ):
     lang = language or _detect_language(q)
     params = {"q": q, "maxResults": 20, "langRestrict": lang}
@@ -90,16 +92,26 @@ def _parse_google_book(info: dict, lang: str = "ko") -> dict:
 
 
 @router.get("/books/isbn/{isbn}")
-async def search_book_by_isbn(isbn: str, db: AsyncSession = Depends(get_db)):
+async def search_book_by_isbn(
+    isbn: str,
+    db: AsyncSession = Depends(get_db),
+    user: CurrentUser = Depends(get_current_user),
+):
     """ISBN으로 책 조회: 로컬 DB 우선 → Google Books 폴백."""
     # 숫자만 추출 (하이픈 등 제거)
     clean_isbn = re.sub(r"[^0-9X]", "", isbn.upper())
     if len(clean_isbn) not in (10, 13):
         raise HTTPException(status_code=400, detail="유효하지 않은 ISBN이에요")
 
-    # 1) 로컬 DB 조회
-    review_count = select(func.count(Review.id)).where(Review.book_id == Book.id, Review.is_deleted.is_(False)).correlate(Book).scalar_subquery()
-    stmt = select(Book, review_count.label("review_count")).where(Book.isbn == clean_isbn, Book.is_deleted.is_(False))
+    # 1) 로컬 DB 조회 (해당 사용자 소유 데이터만)
+    user_id = user.id
+    review_count = (
+        select(func.count(Review.id))
+        .where(Review.book_id == Book.id, Review.user_id == user_id, Review.is_deleted.is_(False))
+        .correlate(Book)
+        .scalar_subquery()
+    )
+    stmt = select(Book, review_count.label("review_count")).where(Book.isbn == clean_isbn, Book.user_id == user_id, Book.is_deleted.is_(False))
     row = (await db.execute(stmt)).first()
     if row:
         book_resp = BookResponse(**row.Book.__dict__, review_count=row.review_count or 0)

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -32,17 +32,20 @@ async def get_current_user(
     except jwt.PyJWTError as err:
         raise HTTPException(status_code=401, detail="유효하지 않은 토큰입니다") from err
 
-    return CurrentUser(
-        id=int(payload["sub"]),
-        email=payload["email"],
-        name=payload["name"],
-    )
+    try:
+        return CurrentUser(
+            id=int(payload["sub"]),
+            email=payload["email"],
+            name=payload["name"],
+        )
+    except (KeyError, ValueError, TypeError) as err:
+        raise HTTPException(status_code=401, detail="유효하지 않은 토큰입니다") from err
 
 
 async def get_optional_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> CurrentUser | None:
-    """For backward compatibility during migration: returns None if no token."""
+    """토큰 없으면 None, 비정상 토큰이면 401."""
     if not credentials:
         return None
     try:
@@ -52,6 +55,9 @@ async def get_optional_user(
             algorithms=[settings.JWT_ALGORITHM],
             issuer="podo-auth",
         )
+    except jwt.PyJWTError as err:
+        raise HTTPException(status_code=401, detail="유효하지 않은 토큰입니다") from err
+    try:
         return CurrentUser(id=int(payload["sub"]), email=payload["email"], name=payload["name"])
-    except jwt.PyJWTError:
-        return None
+    except (KeyError, ValueError, TypeError) as err:
+        raise HTTPException(status_code=401, detail="유효하지 않은 토큰입니다") from err

--- a/backend/app/core/utils.py
+++ b/backend/app/core/utils.py
@@ -1,0 +1,3 @@
+def escape_like(value: str) -> str:
+    """LIKE 패턴 특수문자(%, _, \\)를 이스케이프한다."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,11 +2,11 @@ import asyncio
 import warnings
 from contextlib import asynccontextmanager
 
+from alembic import command
+from alembic.config import Config
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from alembic import command
-from alembic.config import Config
 from app.api.books import router as books_router
 from app.api.export import router as export_router
 from app.api.goals import router as goals_router

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,11 +2,11 @@ import asyncio
 import warnings
 from contextlib import asynccontextmanager
 
-from alembic.config import Config
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from alembic import command
+from alembic.config import Config
 from app.api.books import router as books_router
 from app.api.export import router as export_router
 from app.api.goals import router as goals_router
@@ -41,8 +41,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.CORS_ORIGINS.split(","),
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Authorization", "Content-Type"],
 )
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -34,6 +34,7 @@ ignore = ["E501", "B008"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["app"]
+known-third-party = ["alembic"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,0 +1,138 @@
+"""보안 취약점 수정 테스트 (이슈 #8)."""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.core.auth import CurrentUser, get_current_user, get_optional_user
+from app.core.database import Base, get_db
+from app.main import app
+
+TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
+TEST_USER = CurrentUser(id=1, email="test@example.com", name="테스트")
+
+
+@pytest.fixture
+async def client():
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with async_session() as session:
+            yield session
+
+    async def override_get_current_user():
+        return TEST_USER
+
+    async def override_get_optional_user():
+        return TEST_USER
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_optional_user] = override_get_optional_user
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+@pytest.fixture
+async def unauthenticated_client():
+    """인증 없는 클라이언트 — dependency override 없음."""
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+    # get_current_user, get_optional_user는 override하지 않음 → 토큰 없으면 401
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac
+    app.dependency_overrides.clear()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()
+
+
+# --- C1: LIKE injection ---
+
+
+async def test_like_special_chars_in_book_search(client):
+    """검색어에 % 문자가 있어도 와일드카드로 동작하지 않아야 한다."""
+    await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
+    # '%' 검색은 모든 책에 매칭되면 안 됨
+    resp = await client.get("/api/books", params={"q": "%"})
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+async def test_like_special_chars_in_review_search(client):
+    """리뷰 검색에서도 LIKE 특수문자가 이스케이프되어야 한다."""
+    resp = await client.post(
+        "/api/reviews/with-book",
+        json={"title": "구름빵", "author": "백희나", "read_date": "2026-02-14", "memo": "좋아요"},
+    )
+    assert resp.status_code == 201
+    # '%' 검색은 매칭되면 안 됨
+    resp = await client.get("/api/reviews", params={"q": "%"})
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+# --- C2/C3: 미인증 search 엔드포인트 ---
+
+
+async def test_search_books_requires_auth(unauthenticated_client):
+    """GET /api/search/books는 인증이 필요하다."""
+    resp = await unauthenticated_client.get("/api/search/books", params={"q": "구름빵"})
+    assert resp.status_code == 401
+
+
+async def test_search_isbn_requires_auth(unauthenticated_client):
+    """GET /api/search/books/isbn/{isbn}은 인증이 필요하다."""
+    resp = await unauthenticated_client.get("/api/search/books/isbn/9788901260716")
+    assert resp.status_code == 401
+
+
+# --- C4: JWT payload KeyError ---
+
+
+async def test_jwt_missing_claims():
+    """JWT payload에 필수 필드 누락 시 401 반환."""
+
+    import jwt as pyjwt
+
+    from app.core.config import settings
+
+    # sub만 있고 email, name 없는 토큰
+    token = pyjwt.encode({"sub": "1", "iss": "podo-auth"}, settings.JWT_SECRET, algorithm=settings.JWT_ALGORITHM)
+
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with async_session() as session:
+            yield session
+
+    app.dependency_overrides = {get_db: override_get_db}
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+        headers={"Authorization": f"Bearer {token}"},
+    ) as ac:
+        resp = await ac.get("/api/books")
+    assert resp.status_code == 401
+    app.dependency_overrides.clear()
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.drop_all)
+    await engine.dispose()


### PR DESCRIPTION
## Summary
- LIKE injection 방지: `escape_like` 유틸리티로 `%`, `_` 특수문자 이스케이프
- `GET /api/search/books`, `GET /api/search/books/isbn/{isbn}` 인증 필수 적용
- ISBN 조회 시 `user_id` 필터 추가하여 타 유저 데이터 노출 차단
- JWT payload 필수 필드 누락 시 500 → 401 반환
- `get_optional_user`: 비정상 토큰 시 None이 아닌 401 반환
- CORS `allow_methods`/`allow_headers` 명시적 제한

## Test plan
- [x] LIKE 특수문자(`%`) 검색 시 전체 매칭 안 되는지 확인
- [x] 미인증 search 엔드포인트 접근 시 401 확인
- [x] 불완전 JWT payload로 요청 시 401 확인
- [x] 기존 48개 테스트 전체 통과

close #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)