### PR TITLE
fix: 프론트엔드 인증 관련 버그 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ const BookDetailPage = lazy(() => import("./pages/BookDetailPage"));
 const BookshelfPage = lazy(() => import("./pages/BookshelfPage"));
 const StatsPage = lazy(() => import("./pages/StatsPage"));
 const AuthCallbackPage = lazy(() => import("./pages/AuthCallbackPage"));
+const AuthErrorPage = lazy(() => import("./pages/AuthErrorPage"));
 
 function PageLoading() {
   return (
@@ -29,6 +30,7 @@ export default function App() {
         <Suspense fallback={<PageLoading />}>
           <Routes>
             <Route path="/auth/callback" element={<AuthCallbackPage />} />
+            <Route path="/auth-error" element={<AuthErrorPage />} />
             <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
               <Route path="/" element={<HomePage />} />
               <Route path="/search" element={<SearchPage />} />

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,13 +1,10 @@
 import axios from "axios";
 
+import { getCookieToken } from "../utils/token";
+
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_URL || "/api",
 });
-
-function getCookieToken(): string | null {
-  const match = document.cookie.match(/(?:^|; )podo_access_token=([^;]+)/);
-  return match ? match[1] : null;
-}
 
 api.interceptors.request.use((config) => {
   const token = getCookieToken();
@@ -17,16 +14,27 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+const AUTH_RETRY_KEY = "auth_retry";
+const MAX_AUTH_RETRIES = 2;
+
 api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
+      const retryCount = parseInt(sessionStorage.getItem(AUTH_RETRY_KEY) || "0");
+      if (retryCount >= MAX_AUTH_RETRIES) {
+        sessionStorage.removeItem(AUTH_RETRY_KEY);
+        window.location.href = "/auth-error";
+        return Promise.reject(error);
+      }
+      sessionStorage.setItem(AUTH_RETRY_KEY, String(retryCount + 1));
+
       const authUrl = import.meta.env.VITE_AUTH_URL || "https://auth.podonest.com";
       const callbackUrl = import.meta.env.VITE_AUTH_CALLBACK_URL || `${window.location.origin}/auth/callback`;
       window.location.href = `${authUrl}/login?redirect_uri=${encodeURIComponent(callbackUrl)}`;
     }
     return Promise.reject(error);
-  }
+  },
 );
 
 export default api;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 
+import { clearCookieToken, getCookieToken } from "../utils/token";
+
 interface UserInfo {
   id: string;
   email: string;
@@ -33,27 +35,6 @@ function isTokenExpired(token: string): boolean {
   } catch {
     return true;
   }
-}
-
-function getCookieToken(): string | null {
-  // 1. 쿠키 우선 (Chrome/Android 등)
-  const cookieMatch = document.cookie.match(/(?:^|; )podo_access_token=([^;]+)/);
-  if (cookieMatch) return cookieMatch[1];
-  // 2. localStorage 폴백 (iOS Safari ITP가 JS 쿠키를 삭제하는 경우)
-  try {
-    return localStorage.getItem("podo_access_token");
-  } catch {
-    return null;
-  }
-}
-
-function clearCookieToken(): void {
-  const hostname = window.location?.hostname || "";
-  const domain = hostname.endsWith("podonest.com") ? ".podonest.com" : "";
-  const domainAttr = domain ? `Domain=${domain}; ` : "";
-  const secure = window.location.protocol === "https:" ? "Secure; " : "";
-  document.cookie = `podo_access_token=; ${domainAttr}${secure}SameSite=Lax; Path=/; Max-Age=0`;
-  try { localStorage.removeItem("podo_access_token"); } catch { /* localStorage 미지원 환경 무시 */ }
 }
 
 const AuthContext = createContext<AuthState>({

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -14,8 +14,12 @@ export default function AuthCallbackPage() {
       } catch {
         // private browsing 등 localStorage 접근 불가 시 무시
       }
+      // URL에서 토큰 즉시 제거 (Referrer, 브라우저 히스토리 노출 방지)
       window.history.replaceState({}, "", window.location.pathname);
     }
+
+    // 인증 성공 → 리다이렉트 카운터 초기화
+    sessionStorage.removeItem("auth_retry");
 
     const intendedPath = sessionStorage.getItem("intended_path") || "/";
     sessionStorage.removeItem("intended_path");

--- a/frontend/src/pages/AuthErrorPage.tsx
+++ b/frontend/src/pages/AuthErrorPage.tsx
@@ -1,0 +1,27 @@
+import { clearCookieToken } from "../utils/token";
+
+export default function AuthErrorPage() {
+  const handleRetry = () => {
+    clearCookieToken();
+    sessionStorage.removeItem("auth_retry");
+    const authUrl = import.meta.env.VITE_AUTH_URL || "https://auth.podonest.com";
+    const callbackUrl =
+      import.meta.env.VITE_AUTH_CALLBACK_URL || `${window.location.origin}/auth/callback`;
+    window.location.href = `${authUrl}/login?redirect_uri=${encodeURIComponent(callbackUrl)}`;
+  };
+
+  return (
+    <div className="flex h-screen flex-col items-center justify-center gap-4 text-center">
+      <p className="text-lg font-semibold text-grape-600">로그인에 문제가 발생했어요</p>
+      <p className="text-sm text-warm-500">
+        반복적으로 인증에 실패했습니다. 다시 시도해 주세요.
+      </p>
+      <button
+        onClick={handleRetry}
+        className="rounded-lg bg-grape-500 px-6 py-2 text-white hover:bg-grape-600"
+      >
+        다시 로그인
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/utils/token.ts
+++ b/frontend/src/utils/token.ts
@@ -1,0 +1,27 @@
+/**
+ * 토큰 접근 유틸리티 — cookie 우선, localStorage 폴백 (iOS Safari ITP 대응)
+ * client.ts와 AuthContext에서 공유한다.
+ */
+
+export function getCookieToken(): string | null {
+  const cookieMatch = document.cookie.match(/(?:^|; )podo_access_token=([^;]+)/);
+  if (cookieMatch) return cookieMatch[1];
+  try {
+    return localStorage.getItem("podo_access_token");
+  } catch {
+    return null;
+  }
+}
+
+export function clearCookieToken(): void {
+  const hostname = window.location?.hostname || "";
+  const domain = hostname.endsWith("podonest.com") ? ".podonest.com" : "";
+  const domainAttr = domain ? `Domain=${domain}; ` : "";
+  const secure = window.location.protocol === "https:" ? "Secure; " : "";
+  document.cookie = `podo_access_token=; ${domainAttr}${secure}SameSite=Lax; Path=/; Max-Age=0`;
+  try {
+    localStorage.removeItem("podo_access_token");
+  } catch {
+    /* localStorage 미지원 환경 무시 */
+  }
+}


### PR DESCRIPTION
## Summary
- `getCookieToken`을 `utils/token.ts`로 추출 — client.ts와 AuthContext 간 불일치 해소
- API client에 localStorage 폴백 추가 (iOS Safari ITP 환경에서 401 방지)
- 401 무한 리다이렉트 방지: 서킷 브레이커 (2회 초과 시 `/auth-error` 페이지로 이동)
- AuthCallbackPage에서 성공 시 리다이렉트 카운터 초기화
- `/auth-error` 에러 페이지 추가 (재로그인 버튼 포함)

## Test plan
- [x] ESLint + TypeScript 타입 체크 통과
- [x] 백엔드 48개 테스트 통과
- [ ] iOS Safari에서 로그인/토큰 만료/재로그인 플로우 수동 테스트
- [ ] 비정상 토큰으로 콜백 시 에러 페이지 표시 확인

close #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)