### PR TITLE
fix: 데이터 무결성 이슈 수정

### DIFF
--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
@@ -173,6 +173,13 @@ async def delete_book(
     book = result.scalar_one_or_none()
     if not book:
         raise HTTPException(status_code=404, detail="책을 찾을 수 없습니다")
+    now = datetime.now(UTC)
     book.is_deleted = True
-    book.deleted_at = datetime.now()
+    book.deleted_at = now
+    # 연결된 리뷰도 함께 soft delete
+    review_stmt = select(Review).where(Review.book_id == book_id, Review.user_id == user_id, Review.is_deleted.is_(False))
+    reviews = (await db.execute(review_stmt)).scalars().all()
+    for review in reviews:
+        review.is_deleted = True
+        review.deleted_at = now
     await db.commit()

--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
@@ -50,6 +50,8 @@ async def export_all(
                 "read_date": _serialize(r.read_date),
                 "memo": r.memo,
                 "activity": r.activity,
+                "tags": r.tags or [],
+                "child_age_months": r.child_age_months,
                 "created_at": _serialize(r.created_at),
                 "updated_at": _serialize(r.updated_at),
             }
@@ -57,7 +59,7 @@ async def export_all(
 
     return JSONResponse(
         content={
-            "exported_at": datetime.now().isoformat(),
+            "exported_at": datetime.now(UTC).isoformat(),
             "books": books,
             "reviews": reviews,
             "counts": {"books": len(books), "reviews": len(reviews)},

--- a/backend/tests/test_api_books.py
+++ b/backend/tests/test_api_books.py
@@ -5,12 +5,14 @@ async def test_create_book(client):
     assert data["title"] == "구름빵"
     assert "id" in data
 
+
 async def test_list_books(client):
     await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
     await client.post("/api/books", json={"title": "팥빙수의 전설", "author": "이지은"})
     resp = await client.get("/api/books")
     assert resp.status_code == 200
     assert len(resp.json()["items"]) == 2
+
 
 async def test_get_book(client):
     create = await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
@@ -19,12 +21,14 @@ async def test_get_book(client):
     assert resp.status_code == 200
     assert resp.json()["title"] == "구름빵"
 
+
 async def test_update_book(client):
     create = await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
     book_id = create.json()["id"]
     resp = await client.put(f"/api/books/{book_id}", json={"title": "구름빵 (개정판)"})
     assert resp.status_code == 200
     assert resp.json()["title"] == "구름빵 (개정판)"
+
 
 async def test_delete_book(client):
     create = await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
@@ -71,3 +75,19 @@ async def test_get_book_not_found(client):
 async def test_create_book_missing_title(client):
     resp = await client.post("/api/books", json={"author": "백희나"})
     assert resp.status_code == 422
+
+
+async def test_delete_book_cascades_reviews(client):
+    """책 삭제 시 연결된 리뷰도 함께 soft delete되어야 한다."""
+    book = await client.post("/api/books", json={"title": "삭제 테스트", "author": "테스트"})
+    book_id = book.json()["id"]
+    await client.post("/api/reviews", json={"book_id": book_id, "read_date": "2026-02-15", "memo": "리뷰1"})
+    await client.post("/api/reviews", json={"book_id": book_id, "read_date": "2026-02-16", "memo": "리뷰2"})
+
+    # 책 삭제
+    resp = await client.delete(f"/api/books/{book_id}")
+    assert resp.status_code == 204
+
+    # 리뷰 목록에서 해당 리뷰 미노출
+    reviews = await client.get("/api/reviews")
+    assert reviews.json()["total"] == 0

--- a/backend/tests/test_api_export.py
+++ b/backend/tests/test_api_export.py
@@ -26,3 +26,26 @@ async def test_export_content_disposition_header(client):
     assert "content-disposition" in resp.headers
     assert "attachment" in resp.headers["content-disposition"]
     assert "podo-backup-" in resp.headers["content-disposition"]
+
+
+async def test_export_includes_all_review_fields(client):
+    """export에 tags, activity, child_age_months 필드가 포함되어야 한다."""
+    book = await client.post("/api/books", json={"title": "필드 테스트", "author": "테스트"})
+    book_id = book.json()["id"]
+    await client.post(
+        "/api/reviews",
+        json={
+            "book_id": book_id,
+            "read_date": "2026-02-15",
+            "memo": "메모",
+            "activity": "따라 읽기",
+            "tags": ["그림책", "잠자리"],
+            "child_age_months": 36,
+        },
+    )
+
+    resp = await client.get("/api/export")
+    review = resp.json()["reviews"][0]
+    assert review["activity"] == "따라 읽기"
+    assert review["tags"] == ["그림책", "잠자리"]
+    assert review["child_age_months"] == 36


### PR DESCRIPTION
## Summary
- 책 soft delete 시 연결된 리뷰도 함께 soft delete (orphan 리뷰 방지)
- `datetime.now()` → `datetime.now(UTC)` 통일 (books.py, export.py)
- export에 `tags`, `child_age_months` 필드 추가 (데이터 내보내기 누락 방지)

## Test plan
- [x] 책 삭제 후 리뷰 목록에서 해당 리뷰 미노출 확인
- [x] export 데이터에 tags, child_age_months 포함 확인
- [x] 기존 50개 테스트 전체 통과

close #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)