### PR TITLE
fix: 입력 검증 강화

### DIFF
--- a/backend/app/api/goals.py
+++ b/backend/app/api/goals.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import extract, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,8 +15,8 @@ router = APIRouter(prefix="/api/goals", tags=["goals"])
 
 
 class GoalUpdate(BaseModel):
-    monthly: int | None = None
-    yearly: int | None = None
+    monthly: int | None = Field(None, ge=0)
+    yearly: int | None = Field(None, ge=0)
 
 
 @router.get("")

--- a/backend/app/api/reviews.py
+++ b/backend/app/api/reviews.py
@@ -23,11 +23,14 @@ async def create_review(
     user: CurrentUser = Depends(get_current_user),
 ):
     user_id = user.id
-    book_query = select(Book).where(Book.id == data.book_id, Book.is_deleted.is_(False), Book.user_id == user_id)
+    book_id = int(data.book_id)
+    book_query = select(Book).where(Book.id == book_id, Book.is_deleted.is_(False), Book.user_id == user_id)
     book = (await db.execute(book_query)).scalar_one_or_none()
     if not book:
         raise HTTPException(status_code=404, detail="책을 찾을 수 없습니다")
-    review = Review(id=generate_tsid(), user_id=user_id, **data.model_dump())
+    review_data = data.model_dump()
+    review_data["book_id"] = book_id
+    review = Review(id=generate_tsid(), user_id=user_id, **review_data)
     db.add(review)
     await db.commit()
     await db.refresh(review)

--- a/backend/app/schemas/book.py
+++ b/backend/app/schemas/book.py
@@ -21,8 +21,8 @@ class BookCreate(BookBase):
 
 
 class BookUpdate(BaseModel):
-    title: str | None = None
-    author: str | None = None
+    title: str | None = Field(None, min_length=1, max_length=500)
+    author: str | None = Field(None, min_length=1, max_length=200)
     cover_url: str | None = None
     isbn: str | None = None
     publisher: str | None = None

--- a/backend/tests/test_api_books.py
+++ b/backend/tests/test_api_books.py
@@ -77,6 +77,14 @@ async def test_create_book_missing_title(client):
     assert resp.status_code == 422
 
 
+async def test_update_book_empty_title_rejected(client):
+    """빈 문자열로 제목 업데이트는 거부되어야 한다."""
+    create = await client.post("/api/books", json={"title": "구름빵", "author": "백희나"})
+    book_id = create.json()["id"]
+    resp = await client.put(f"/api/books/{book_id}", json={"title": ""})
+    assert resp.status_code == 422
+
+
 async def test_delete_book_cascades_reviews(client):
     """책 삭제 시 연결된 리뷰도 함께 soft delete되어야 한다."""
     book = await client.post("/api/books", json={"title": "삭제 테스트", "author": "테스트"})

--- a/backend/tests/test_api_goals.py
+++ b/backend/tests/test_api_goals.py
@@ -25,3 +25,15 @@ async def test_get_goals_after_update(client):
     data = resp.json()
     assert data["monthly_goal"] == 5
     assert data["yearly_goal"] == 50
+
+
+async def test_update_goals_negative_rejected(client):
+    """음수 목표는 거부되어야 한다."""
+    resp = await client.put("/api/goals", json={"monthly": -1})
+    assert resp.status_code == 422
+
+
+async def test_update_goals_zero_allowed(client):
+    """0 목표는 허용되어야 한다."""
+    resp = await client.put("/api/goals", json={"monthly": 0, "yearly": 0})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- `BookUpdate`에 `title`/`author` min_length=1 제약 추가 (빈 문자열로 업데이트 방지)
- `GoalUpdate`에 `ge=0` 제약 추가 (음수 목표 설정 방지)
- `create_review`에서 `book_id`를 `int`로 명시적 변환 (PostgreSQL 호환)

## Test plan
- [x] 빈 문자열로 책 제목 업데이트 시 422 확인
- [x] 음수 목표 설정 시 422 확인
- [x] 0 목표 설정은 정상 동작 확인
- [x] 기존 53개 테스트 전체 통과

close #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)