### PR TITLE
fix: Frontend-Backend 타입 계약 불일치 수정

### DIFF
--- a/backend/app/api/reviews.py
+++ b/backend/app/api/reviews.py
@@ -11,7 +11,7 @@ from app.core.utils import escape_like
 from app.models.book import Book
 from app.models.review import Review
 from app.schemas.book import BookResponse
-from app.schemas.review import ReviewCreate, ReviewCreateWithBook, ReviewDetailResponse, ReviewResponse, ReviewUpdate
+from app.schemas.review import PaginatedReviews, ReviewCreate, ReviewCreateWithBook, ReviewDetailResponse, ReviewResponse, ReviewUpdate
 
 router = APIRouter(prefix="/api/reviews", tags=["reviews"])
 
@@ -87,7 +87,7 @@ async def create_review_with_book(
     return {**detail.model_dump(), "total_reviews": total}
 
 
-@router.get("")
+@router.get("", response_model=PaginatedReviews)
 async def list_reviews(
     q: str | None = Query(None),
     language: str | None = Query(None),

--- a/backend/app/schemas/review.py
+++ b/backend/app/schemas/review.py
@@ -63,3 +63,10 @@ class ReviewResponse(ReviewBase):
 
 class ReviewDetailResponse(ReviewResponse):
     book: BookResponse
+
+
+class PaginatedReviews(BaseModel):
+    items: list[ReviewDetailResponse]
+    total: int
+    page: int
+    size: int

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -23,7 +23,7 @@ export interface Review {
   child_age_months: number | null;
   created_at: string;
   updated_at: string | null;
-  book: Book;
+  book?: Book;
 }
 
 export interface PaginatedReviews {
@@ -47,6 +47,7 @@ export interface BookSearchResult {
   cover_url: string;
   isbn: string | null;
   language: string;
+  is_children: boolean;
 }
 
 export interface IsbnLookupResult {


### PR DESCRIPTION
## Summary
- `Review.book`을 optional로 변경 (`ReviewResponse`에는 book 미포함, `ReviewDetailResponse`에만 포함)
- `BookSearchResult`에 `is_children: boolean` 필드 추가 (백엔드 응답과 일치)
- `PaginatedReviews` Pydantic 스키마 생성 + `GET /api/reviews`에 `response_model` 적용

## Test plan
- [x] TypeScript strict 타입 체크 0 에러
- [x] ESLint 통과
- [x] 백엔드 53개 테스트 전체 통과

close #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)