### PR TITLE
improvement: UX/접근성 개선

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
-import { lazy, Suspense } from "react";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { Component, lazy, Suspense } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
 import Layout from "./components/layout/Layout";
 import { AuthProvider } from "./context/AuthContext";
 import ProtectedRoute from "./components/ProtectedRoute";
@@ -23,26 +24,83 @@ function PageLoading() {
   );
 }
 
+// 404 페이지
+function NotFoundPage() {
+  return (
+    <div className="flex h-64 flex-col items-center justify-center gap-4">
+      <p className="text-4xl font-bold text-grape-300">404</p>
+      <p className="text-warm-600">페이지를 찾을 수 없어요</p>
+      <Link
+        to="/"
+        className="rounded-lg bg-grape-600 px-4 py-2 text-sm text-white hover:bg-grape-700"
+      >
+        홈으로 돌아가기
+      </Link>
+    </div>
+  );
+}
+
+// 전역 에러 바운더리
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryState> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-64 flex-col items-center justify-center gap-4">
+          <p className="text-lg font-semibold text-warm-700">문제가 발생했어요</p>
+          <p className="text-sm text-warm-500">예상치 못한 오류가 발생했어요.</p>
+          <button
+            onClick={() => this.setState({ hasError: false })}
+            className="rounded-lg bg-grape-600 px-4 py-2 text-sm text-white hover:bg-grape-700"
+          >
+            다시 시도
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
 export default function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <Suspense fallback={<PageLoading />}>
-          <Routes>
-            <Route path="/auth/callback" element={<AuthCallbackPage />} />
-            <Route path="/auth-error" element={<AuthErrorPage />} />
-            <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
-              <Route path="/" element={<HomePage />} />
-              <Route path="/search" element={<SearchPage />} />
-              <Route path="/bookshelf" element={<BookshelfPage />} />
-              <Route path="/write" element={<WriteReviewPage />} />
-              <Route path="/reviews" element={<ReviewListPage />} />
-              <Route path="/reviews/:id" element={<ReviewDetailPage />} />
-              <Route path="/books/:id" element={<BookDetailPage />} />
-              <Route path="/stats" element={<StatsPage />} />
-            </Route>
-          </Routes>
-        </Suspense>
+        <ErrorBoundary>
+          <Suspense fallback={<PageLoading />}>
+            <Routes>
+              <Route path="/auth/callback" element={<AuthCallbackPage />} />
+              <Route path="/auth-error" element={<AuthErrorPage />} />
+              <Route element={<ProtectedRoute><Layout /></ProtectedRoute>}>
+                <Route path="/" element={<HomePage />} />
+                <Route path="/search" element={<SearchPage />} />
+                <Route path="/bookshelf" element={<BookshelfPage />} />
+                <Route path="/write" element={<WriteReviewPage />} />
+                <Route path="/reviews" element={<ReviewListPage />} />
+                <Route path="/reviews/:id" element={<ReviewDetailPage />} />
+                <Route path="/books/:id" element={<BookDetailPage />} />
+                <Route path="/stats" element={<StatsPage />} />
+              </Route>
+              <Route path="*" element={<NotFoundPage />} />
+            </Routes>
+          </Suspense>
+        </ErrorBoundary>
       </AuthProvider>
     </BrowserRouter>
   );

--- a/frontend/src/components/BarcodeScanner.tsx
+++ b/frontend/src/components/BarcodeScanner.tsx
@@ -84,7 +84,12 @@ export default function BarcodeScanner({ isOpen, onScan, onClose }: Props) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col bg-black">
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-black"
+      role="dialog"
+      aria-modal="true"
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+    >
       {/* 헤더 */}
       <div className="flex items-center justify-between px-4 py-3">
         <div className="flex items-center gap-2 text-white">

--- a/frontend/src/components/MilestoneModal.tsx
+++ b/frontend/src/components/MilestoneModal.tsx
@@ -36,7 +36,13 @@ export default function MilestoneModal({ total, onClose }: Props) {
   if (!milestone) return null;
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40" onClick={onClose}>
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+    >
       {/* Confetti */}
       {particles.map((p) => (
         <div

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft, Heart, PenSquare, Trash2 } from "lucide-react";
 import toast from "react-hot-toast";
 import { getBook, getBookReviews, toggleFavorite, deleteBook } from "../api/books";
+import { getLanguageLabel } from "../utils/language";
 import type { Book, Review } from "../types";
 
 export default function BookDetailPage() {
@@ -77,7 +78,7 @@ export default function BookDetailPage() {
           {book.publisher && <p className="text-xs text-warm-500">{book.publisher}</p>}
           {book.language && (
             <span className="mt-1 inline-block rounded-full bg-warm-100 px-2 py-0.5 text-xs text-warm-500">
-              {book.language === "ko" ? "한글" : "영어"}
+              {getLanguageLabel(book.language)}
             </span>
           )}
           <p className="mt-2 text-sm font-medium text-grape-600">
@@ -123,7 +124,13 @@ export default function BookDetailPage() {
 
       {/* 삭제 확인 모달 */}
       {showDeleteConfirm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={() => setShowDeleteConfirm(false)}>
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setShowDeleteConfirm(false)}
+          onKeyDown={(e) => { if (e.key === "Escape") setShowDeleteConfirm(false); }}
+        >
           <div className="mx-4 w-full max-w-sm rounded-2xl bg-white p-6" onClick={(e) => e.stopPropagation()}>
             <p className="text-center font-medium text-warm-900">
               "{book.title}"을(를) 삭제할까요?

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useReducer, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { BookOpen, Plus, Settings2 } from "lucide-react";
+import { BookOpen, Plus, RefreshCw, Settings2 } from "lucide-react";
 import toast from "react-hot-toast";
 import { getStats } from "../api/stats";
 import { getReviews } from "../api/reviews";
@@ -48,14 +48,27 @@ export default function HomePage() {
   const [monthlyGoal, setMonthlyGoal] = useState("");
   const [yearlyGoal, setYearlyGoal] = useState("");
   const [childBirthdate, setChildBirthdate] = useState("");
+  // loadState: "idle" | "error" | "ok" — 재시도 시 retryCount 증가로 effect 재실행
+  const [loadState, setLoadState] = useState<"idle" | "error" | "ok">("idle");
+  const [retryCount, incrementRetry] = useReducer((c: number) => c + 1, 0);
 
   useEffect(() => {
+    let cancelled = false;
     Promise.allSettled([
       getStats(),
       getReviews({ size: 5 }),
       api.get<Goals>("/goals"),
       api.get<{ child_birthdate?: string }>("/settings"),
     ]).then(([statsResult, reviewsResult, goalsResult, settingsResult]) => {
+      if (cancelled) return;
+      // 모든 API 호출이 실패하면 에러 표시
+      const allFailed = [statsResult, reviewsResult, goalsResult, settingsResult]
+        .every((r) => r.status === "rejected");
+      if (allFailed) {
+        setLoadState("error");
+        return;
+      }
+      setLoadState("ok");
       if (statsResult.status === "fulfilled") setStats(statsResult.value);
       if (reviewsResult.status === "fulfilled") setRecentReviews(reviewsResult.value.items);
       if (goalsResult.status === "fulfilled") {
@@ -66,7 +79,8 @@ export default function HomePage() {
       }
       if (settingsResult.status === "fulfilled") setChildBirthdate(settingsResult.value.data.child_birthdate || "");
     });
-  }, [location.key]);
+    return () => { cancelled = true; };
+  }, [location.key, retryCount]);
 
   const saveGoals = async () => {
     try {
@@ -81,6 +95,22 @@ export default function HomePage() {
       toast.error("목표 저장에 실패했어요");
     }
   };
+
+  if (loadState === "error") {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-4">
+        <p className="font-semibold text-warm-700">데이터를 불러오지 못했어요</p>
+        <p className="text-sm text-warm-500">네트워크 연결을 확인하고 다시 시도해주세요.</p>
+        <button
+          onClick={incrementRetry}
+          className="flex items-center gap-2 rounded-lg bg-grape-600 px-4 py-2 text-sm text-white hover:bg-grape-700"
+        >
+          <RefreshCw size={14} />
+          다시 시도
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/ReviewDetailPage.tsx
+++ b/frontend/src/pages/ReviewDetailPage.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, BookOpen, PenSquare, Pencil, Trash2, X } from "lucide-react"
 import toast from "react-hot-toast";
 import { getReview, updateReview, deleteReview } from "../api/reviews";
 import api from "../api/client";
+import { getLanguageLabel } from "../utils/language";
 import type { Review } from "../types";
 
 export default function ReviewDetailPage() {
@@ -18,6 +19,8 @@ export default function ReviewDetailPage() {
   const [readDate, setReadDate] = useState("");
   const [childAgeMonths, setChildAgeMonths] = useState<number | null>(null);
   const [childBirthdate, setChildBirthdate] = useState("");
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
   // 수정 모드에서 생년월일+읽은날짜로 나이 자동 계산 (파생값, setState 없음)
   const ageMonths = useMemo(() => {
@@ -94,13 +97,16 @@ export default function ReviewDetailPage() {
   };
 
   const handleDelete = async () => {
-    if (!id || !confirm("정말 삭제할까요?")) return;
+    if (!id) return;
+    setDeleting(true);
     try {
       await deleteReview(id);
       toast.success("삭제되었어요");
       navigate("/reviews");
     } catch {
       toast.error("삭제에 실패했어요");
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -124,7 +130,7 @@ export default function ReviewDetailPage() {
           {review.book.publisher && <p className="text-xs text-warm-500">{review.book.publisher}</p>}
           {review.book.language && (
             <span className="mt-1 inline-block rounded-full bg-warm-100 px-2 py-0.5 text-xs text-warm-500">
-              {review.book.language === "ko" ? "한글" : "영어"}
+              {getLanguageLabel(review.book.language)}
             </span>
           )}
           <div className="mt-2 flex items-center gap-3">
@@ -151,7 +157,7 @@ export default function ReviewDetailPage() {
             <button onClick={() => setEditing(!editing)} className="rounded-lg p-2 text-warm-400 hover:bg-warm-100 hover:text-grape-600">
               <Pencil size={16} />
             </button>
-            <button onClick={handleDelete} className="rounded-lg p-2 text-warm-400 hover:bg-red-50 hover:text-red-500">
+            <button onClick={() => setShowDeleteConfirm(true)} className="rounded-lg p-2 text-warm-400 hover:bg-red-50 hover:text-red-500">
               <Trash2 size={16} />
             </button>
           </div>
@@ -266,6 +272,38 @@ export default function ReviewDetailPage() {
           </div>
         )}
       </div>
+
+      {/* 삭제 확인 모달 */}
+      {showDeleteConfirm && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          role="dialog"
+          aria-modal="true"
+          onClick={() => setShowDeleteConfirm(false)}
+          onKeyDown={(e) => { if (e.key === "Escape") setShowDeleteConfirm(false); }}
+        >
+          <div className="mx-4 w-full max-w-sm rounded-2xl bg-white p-6" onClick={(e) => e.stopPropagation()}>
+            <p className="text-center font-medium text-warm-900">
+              이 리딩 로그를 삭제할까요?
+            </p>
+            <div className="mt-5 flex gap-3">
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                className="flex-1 rounded-lg border border-warm-200 py-2.5 text-sm text-warm-600 hover:bg-warm-50"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="flex-1 rounded-lg bg-red-500 py-2.5 text-sm text-white hover:bg-red-600 disabled:opacity-50"
+              >
+                {deleting ? "삭제 중..." : "삭제"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -5,6 +5,7 @@ import toast from "react-hot-toast";
 import { searchBooks, searchBookByIsbn } from "../api/search";
 import { getBooks, createBook } from "../api/books";
 import BarcodeScanner from "../components/BarcodeScanner";
+import { getLanguageLabel } from "../utils/language";
 import type { Book, BookSearchResult } from "../types";
 
 export default function SearchPage() {
@@ -194,7 +195,10 @@ export default function SearchPage() {
       {selectedBook && (
         <div
           className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+          role="dialog"
+          aria-modal="true"
           onClick={() => setSelectedBook(null)}
+          onKeyDown={(e) => { if (e.key === "Escape") setSelectedBook(null); }}
         >
           <div
             className="mx-4 w-full max-w-sm rounded-2xl bg-white p-6"
@@ -217,7 +221,7 @@ export default function SearchPage() {
                 )}
                 {selectedBook.language && (
                   <span className="mt-2 inline-block rounded-full bg-warm-100 px-2 py-0.5 text-xs text-warm-500">
-                    {selectedBook.language === "ko" ? "한글" : "영어"}
+                    {getLanguageLabel(selectedBook.language)}
                   </span>
                 )}
               </div>

--- a/frontend/src/utils/language.ts
+++ b/frontend/src/utils/language.ts
@@ -1,0 +1,11 @@
+// 언어 코드 → 표시 라벨 매핑
+const LANGUAGE_LABELS: Record<string, string> = {
+  ko: "한글",
+  en: "English",
+  ja: "日本語",
+  zh: "中文",
+};
+
+export function getLanguageLabel(code: string | null): string {
+  return code ? (LANGUAGE_LABELS[code] || code.toUpperCase()) : "";
+}


### PR DESCRIPTION
## Summary
- 404 catch-all 라우트 + NotFoundPage 컴포넌트 추가
- React ErrorBoundary 추가 (렌더링 에러 시 에러 UI + 재시도 버튼)
- 언어 표시: `ko/en` 이분법 → 다국어 매핑 유틸리티 (`ko`, `en`, `ja`, `zh` 등)
- ReviewDetailPage: `window.confirm()` → 커스텀 확인 모달로 교체
- HomePage: 전체 API 실패 시 에러 메시지 + 재시도 버튼 표시
- 모달 접근성: `role="dialog"`, `aria-modal="true"`, Escape 키로 닫기

## Test plan
- [x] ESLint + TypeScript 타입 체크 통과
- [ ] 존재하지 않는 URL 접근 시 404 페이지 확인
- [ ] 모달에서 Escape 키로 닫기 동작 확인
- [ ] 네트워크 오프라인 시 HomePage 에러 메시지 확인

close #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)