### PR TITLE
refactor: 백엔드 Services 레이어 도입

### DIFF
--- a/backend/app/api/books.py
+++ b/backend/app/api/books.py
@@ -13,6 +13,7 @@ from app.models.book import Book
 from app.models.review import Review
 from app.schemas.book import BookCreate, BookResponse, BookUpdate, PaginatedBooks
 from app.schemas.review import ReviewResponse
+from app.services.book_service import get_review_count, review_count_subquery
 
 router = APIRouter(prefix="/api/books", tags=["books"])
 
@@ -26,11 +27,14 @@ async def create_book(
     user_id = user.id
     # ISBN 중복 체크: 해당 사용자의 서재에서만 중복 방지
     if data.isbn:
-        existing_query = select(Book).where(Book.isbn == data.isbn, Book.is_deleted.is_(False), Book.user_id == user_id)
+        existing_query = select(Book).where(
+            Book.isbn == data.isbn,
+            Book.is_deleted.is_(False),
+            Book.user_id == user_id,
+        )
         existing = (await db.execute(existing_query)).scalar_one_or_none()
         if existing:
-            review_count_stmt = select(func.count(Review.id)).where(Review.book_id == existing.id, Review.user_id == user_id, Review.is_deleted.is_(False))
-            count = (await db.execute(review_count_stmt)).scalar() or 0
+            count = await get_review_count(db, book_id=existing.id, user_id=user_id)
             resp = BookResponse(**existing.__dict__, review_count=count)
             return JSONResponse(content=resp.model_dump(mode="json"), status_code=200)
 
@@ -51,20 +55,25 @@ async def list_books(
     user: CurrentUser = Depends(get_current_user),
 ):
     user_id = user.id
-    review_count = (
-        select(func.count(Review.id))
-        .where(Review.book_id == Book.id, Review.user_id == user_id, Review.is_deleted.is_(False))
-        .correlate(Book)
-        .scalar_subquery()
-    )
-    base = select(Book, review_count.label("review_count")).where(Book.is_deleted.is_(False), Book.user_id == user_id)
+    rc = review_count_subquery(user_id)
+    base = select(Book, rc.label("review_count")).where(Book.is_deleted.is_(False), Book.user_id == user_id)
     if q:
-        base = base.where(or_(Book.title.ilike(f"%{escape_like(q)}%", escape="\\"), Book.author.ilike(f"%{escape_like(q)}%", escape="\\")))
+        base = base.where(
+            or_(
+                Book.title.ilike(f"%{escape_like(q)}%", escape="\\"),
+                Book.author.ilike(f"%{escape_like(q)}%", escape="\\"),
+            )
+        )
 
     # total count
     count_query = select(Book.id).where(Book.is_deleted.is_(False), Book.user_id == user_id)
     if q:
-        count_query = count_query.where(or_(Book.title.ilike(f"%{escape_like(q)}%", escape="\\"), Book.author.ilike(f"%{escape_like(q)}%", escape="\\")))
+        count_query = count_query.where(
+            or_(
+                Book.title.ilike(f"%{escape_like(q)}%", escape="\\"),
+                Book.author.ilike(f"%{escape_like(q)}%", escape="\\"),
+            )
+        )
     count_stmt = select(func.count()).select_from(count_query.subquery())
     total = (await db.execute(count_stmt)).scalar() or 0
 
@@ -72,13 +81,17 @@ async def list_books(
     if sort == "title":
         base = base.order_by(Book.title)
     elif sort == "most_read":
-        base = base.order_by(review_count.desc(), Book.id.desc())
+        base = base.order_by(rc.desc(), Book.id.desc())
     elif sort == "newest":
         base = base.order_by(Book.id.desc())
     else:  # recent (기본) — 가장 최근 읽은 날짜 순
         latest_read = (
             select(func.max(Review.read_date))
-            .where(Review.book_id == Book.id, Review.user_id == user_id, Review.is_deleted.is_(False))
+            .where(
+                Review.book_id == Book.id,
+                Review.user_id == user_id,
+                Review.is_deleted.is_(False),
+            )
             .correlate(Book)
             .scalar_subquery()
         )
@@ -97,7 +110,11 @@ async def list_book_reviews(
     db: AsyncSession = Depends(get_db),
     user: CurrentUser = Depends(get_current_user),
 ):
-    stmt = select(Review).where(Review.book_id == book_id, Review.is_deleted.is_(False), Review.user_id == user.id)
+    stmt = select(Review).where(
+        Review.book_id == book_id,
+        Review.is_deleted.is_(False),
+        Review.user_id == user.id,
+    )
     stmt = stmt.order_by(Review.read_date.desc())
     result = await db.execute(stmt)
     return result.scalars().all()
@@ -110,13 +127,16 @@ async def get_book(
     user: CurrentUser = Depends(get_current_user),
 ):
     user_id = user.id
-    stmt = select(Book).where(Book.id == book_id, Book.is_deleted.is_(False), Book.user_id == user_id)
+    stmt = select(Book).where(
+        Book.id == book_id,
+        Book.is_deleted.is_(False),
+        Book.user_id == user_id,
+    )
     result = await db.execute(stmt)
     book = result.scalar_one_or_none()
     if not book:
         raise HTTPException(status_code=404, detail="책을 찾을 수 없습니다")
-    review_count_stmt = select(func.count(Review.id)).where(Review.book_id == book_id, Review.user_id == user_id, Review.is_deleted.is_(False))
-    count = (await db.execute(review_count_stmt)).scalar() or 0
+    count = await get_review_count(db, book_id=book_id, user_id=user_id)
     return BookResponse(**book.__dict__, review_count=count)
 
 
@@ -128,7 +148,11 @@ async def update_book(
     user: CurrentUser = Depends(get_current_user),
 ):
     user_id = user.id
-    stmt = select(Book).where(Book.id == book_id, Book.is_deleted.is_(False), Book.user_id == user_id)
+    stmt = select(Book).where(
+        Book.id == book_id,
+        Book.is_deleted.is_(False),
+        Book.user_id == user_id,
+    )
     result = await db.execute(stmt)
     book = result.scalar_one_or_none()
     if not book:
@@ -137,8 +161,7 @@ async def update_book(
         setattr(book, key, value)
     await db.commit()
     await db.refresh(book)
-    review_count_stmt = select(func.count(Review.id)).where(Review.book_id == book_id, Review.user_id == user_id, Review.is_deleted.is_(False))
-    count = (await db.execute(review_count_stmt)).scalar() or 0
+    count = await get_review_count(db, book_id=book_id, user_id=user_id)
     return BookResponse(**book.__dict__, review_count=count)
 
 
@@ -149,15 +172,18 @@ async def toggle_favorite(
     user: CurrentUser = Depends(get_current_user),
 ):
     user_id = user.id
-    stmt = select(Book).where(Book.id == book_id, Book.is_deleted.is_(False), Book.user_id == user_id)
+    stmt = select(Book).where(
+        Book.id == book_id,
+        Book.is_deleted.is_(False),
+        Book.user_id == user_id,
+    )
     book = (await db.execute(stmt)).scalar_one_or_none()
     if not book:
         raise HTTPException(status_code=404, detail="책을 찾을 수 없습니다")
     book.is_favorite = not book.is_favorite
     await db.commit()
     await db.refresh(book)
-    review_count_stmt = select(func.count(Review.id)).where(Review.book_id == book_id, Review.user_id == user_id, Review.is_deleted.is_(False))
-    count = (await db.execute(review_count_stmt)).scalar() or 0
+    count = await get_review_count(db, book_id=book_id, user_id=user_id)
     return BookResponse(**book.__dict__, review_count=count)
 
 
@@ -168,7 +194,11 @@ async def delete_book(
     user: CurrentUser = Depends(get_current_user),
 ):
     user_id = user.id
-    stmt = select(Book).where(Book.id == book_id, Book.is_deleted.is_(False), Book.user_id == user_id)
+    stmt = select(Book).where(
+        Book.id == book_id,
+        Book.is_deleted.is_(False),
+        Book.user_id == user_id,
+    )
     result = await db.execute(stmt)
     book = result.scalar_one_or_none()
     if not book:
@@ -177,7 +207,11 @@ async def delete_book(
     book.is_deleted = True
     book.deleted_at = now
     # 연결된 리뷰도 함께 soft delete
-    review_stmt = select(Review).where(Review.book_id == book_id, Review.user_id == user_id, Review.is_deleted.is_(False))
+    review_stmt = select(Review).where(
+        Review.book_id == book_id,
+        Review.user_id == user_id,
+        Review.is_deleted.is_(False),
+    )
     reviews = (await db.execute(review_stmt)).scalars().all()
     for review in reviews:
         review.is_deleted = True

--- a/backend/app/api/search.py
+++ b/backend/app/api/search.py
@@ -2,33 +2,24 @@ import re
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import CurrentUser, get_current_user
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.book import Book
-from app.models.review import Review
 from app.schemas.book import BookResponse
+from app.services.book_service import review_count_subquery
+from app.services.search_service import (
+    GOOGLE_BOOKS_URL,
+    build_google_books_params,
+    detect_language,
+    parse_google_book,
+    sort_children_first,
+)
 
 router = APIRouter(prefix="/api/search", tags=["search"])
-
-GOOGLE_BOOKS_URL = "https://www.googleapis.com/books/v1/volumes"
-
-# 아동/유아 관련 카테고리 키워드
-CHILDREN_CATEGORIES = {"juvenile", "children", "picture book", "그림책", "유아", "아동", "동화"}
-
-_KOREAN_RE = re.compile(r"[\uac00-\ud7af\u3130-\u318f]")
-
-
-def _is_children_book(info: dict) -> bool:
-    categories = " ".join(info.get("categories", [])).lower()
-    return any(kw in categories for kw in CHILDREN_CATEGORIES)
-
-
-def _detect_language(text: str) -> str:
-    return "ko" if _KOREAN_RE.search(text) else "en"
 
 
 @router.get("/books")
@@ -37,10 +28,8 @@ async def search_books(
     language: str | None = Query(None),
     user: CurrentUser = Depends(get_current_user),
 ):
-    lang = language or _detect_language(q)
-    params = {"q": q, "maxResults": 20, "langRestrict": lang}
-    if settings.GOOGLE_BOOKS_API_KEY:
-        params["key"] = settings.GOOGLE_BOOKS_API_KEY
+    lang = language or detect_language(q)
+    params = build_google_books_params(q, lang, max_results=20, api_key=settings.GOOGLE_BOOKS_API_KEY)
 
     async with httpx.AsyncClient() as client:
         resp = await client.get(GOOGLE_BOOKS_URL, params=params)
@@ -48,47 +37,8 @@ async def search_books(
 
     data = resp.json()
     items = data.get("items", [])
-    results = []
-    for item in items:
-        info = item.get("volumeInfo", {})
-        isbn = None
-        for identifier in info.get("industryIdentifiers", []):
-            if identifier["type"] in ("ISBN_13", "ISBN_10"):
-                isbn = identifier["identifier"]
-                break
-        results.append(
-            {
-                "title": info.get("title", ""),
-                "author": ", ".join(info.get("authors", [])),
-                "publisher": info.get("publisher", ""),
-                "cover_url": info.get("imageLinks", {}).get("thumbnail", ""),
-                "isbn": isbn,
-                "language": info.get("language", lang),
-                "is_children": _is_children_book(info),
-            }
-        )
-
-    # 아동서 우선 정렬
-    results.sort(key=lambda x: (not x["is_children"],))
-    return results[:15]
-
-
-def _parse_google_book(info: dict, lang: str = "ko") -> dict:
-    """Google Books volumeInfo → BookSearchResult 형태로 변환."""
-    isbn = None
-    for identifier in info.get("industryIdentifiers", []):
-        if identifier["type"] in ("ISBN_13", "ISBN_10"):
-            isbn = identifier["identifier"]
-            break
-    return {
-        "title": info.get("title", ""),
-        "author": ", ".join(info.get("authors", [])),
-        "publisher": info.get("publisher", ""),
-        "cover_url": info.get("imageLinks", {}).get("thumbnail", ""),
-        "isbn": isbn,
-        "language": info.get("language", lang),
-        "is_children": _is_children_book(info),
-    }
+    results = [parse_google_book(item.get("volumeInfo", {}), lang) for item in items]
+    return sort_children_first(results)
 
 
 @router.get("/books/isbn/{isbn}")
@@ -105,20 +55,19 @@ async def search_book_by_isbn(
 
     # 1) 로컬 DB 조회 (해당 사용자 소유 데이터만)
     user_id = user.id
-    review_count = (
-        select(func.count(Review.id))
-        .where(Review.book_id == Book.id, Review.user_id == user_id, Review.is_deleted.is_(False))
-        .correlate(Book)
-        .scalar_subquery()
+    rc = review_count_subquery(user_id)
+    stmt = select(Book, rc.label("review_count")).where(
+        Book.isbn == clean_isbn,
+        Book.user_id == user_id,
+        Book.is_deleted.is_(False),
     )
-    stmt = select(Book, review_count.label("review_count")).where(Book.isbn == clean_isbn, Book.user_id == user_id, Book.is_deleted.is_(False))
     row = (await db.execute(stmt)).first()
     if row:
         book_resp = BookResponse(**row.Book.__dict__, review_count=row.review_count or 0)
         return {"source": "local", "book": book_resp.model_dump(mode="json")}
 
     # 2) Google Books API 폴백
-    params = {"q": f"isbn:{clean_isbn}", "maxResults": 1}
+    params: dict[str, str | int] = {"q": f"isbn:{clean_isbn}", "maxResults": 1}
     if settings.GOOGLE_BOOKS_API_KEY:
         params["key"] = settings.GOOGLE_BOOKS_API_KEY
 
@@ -132,5 +81,5 @@ async def search_book_by_isbn(
         raise HTTPException(status_code=404, detail="이 바코드의 책 정보를 찾지 못했어요")
 
     info = items[0].get("volumeInfo", {})
-    book_data = _parse_google_book(info)
+    book_data = parse_google_book(info)
     return {"source": "google", "book": book_data}

--- a/backend/app/api/stats.py
+++ b/backend/app/api/stats.py
@@ -1,15 +1,10 @@
-from collections import defaultdict
-from datetime import date
-
 from fastapi import APIRouter, Depends
-from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import CurrentUser, get_current_user
 from app.core.database import get_db
-from app.models.book import Book
-from app.models.review import Review
 from app.schemas.stats import GardenStats
+from app.services.stats_service import get_detail_stats, get_garden_stats
 
 router = APIRouter(prefix="/api/stats", tags=["stats"])
 
@@ -19,89 +14,12 @@ async def get_stats(
     db: AsyncSession = Depends(get_db),
     user: CurrentUser = Depends(get_current_user),
 ):
-    stmt = select(func.count(Review.id)).where(Review.is_deleted == False, Review.user_id == user.id)  # noqa: E712
-    total = (await db.execute(stmt)).scalar() or 0
-    return GardenStats(
-        total_reviews=total,
-        grapes=total % 10,
-        bunches=(total // 10) % 10,
-        trees=total // 100,
-    )
+    return await get_garden_stats(db, user_id=user.id)
 
 
 @router.get("/detail")
-async def get_detail_stats(
+async def get_detail_stats_endpoint(
     db: AsyncSession = Depends(get_db),
     user: CurrentUser = Depends(get_current_user),
 ):
-    base = select(Review, Book).join(Book, Review.book_id == Book.id).where(Review.is_deleted.is_(False), Review.user_id == user.id)
-    rows = (await db.execute(base)).all()
-
-    total = len(rows)
-    if total == 0:
-        return {
-            "total": 0,
-            "monthly": [],
-            "language_ratio": {},
-            "top_authors": [],
-            "most_read_books": [],
-            "streak": 0,
-        }
-
-    # 월별 권수 (최근 12개월)
-    today = date.today()
-    monthly_counts: dict[str, int] = defaultdict(int)
-    for row in rows:
-        key = row.Review.read_date.strftime("%Y-%m")
-        monthly_counts[key] += 1
-
-    monthly = []
-    for i in range(11, -1, -1):
-        m = today.month - i
-        y = today.year
-        while m <= 0:
-            m += 12
-            y -= 1
-        key = f"{y}-{m:02d}"
-        monthly.append({"month": key, "count": monthly_counts.get(key, 0)})
-
-    # 언어 비율
-    lang_counts: dict[str, int] = defaultdict(int)
-    for row in rows:
-        lang = row.Book.language or "ko"
-        lang_counts[lang] += 1
-
-    # 자주 읽은 작가 Top 5
-    author_counts: dict[str, int] = defaultdict(int)
-    for row in rows:
-        author_counts[row.Book.author] += 1
-    top_authors = sorted(author_counts.items(), key=lambda x: -x[1])[:5]
-
-    # 가장 많이 읽은 책 Top 5
-    book_counts: dict[str, dict] = {}
-    for row in rows:
-        bid = str(row.Book.id)
-        if bid not in book_counts:
-            book_counts[bid] = {"id": bid, "title": row.Book.title, "author": row.Book.author, "count": 0}
-        book_counts[bid]["count"] += 1
-    most_read = sorted(book_counts.values(), key=lambda x: -x["count"])[:5]
-
-    # 연속 읽기 일수 (현재 스트릭)
-    read_dates = sorted({row.Review.read_date for row in rows}, reverse=True)
-    streak = 0
-    check = today
-    for d in read_dates:
-        if d == check:
-            streak += 1
-            check = check.replace(day=check.day) if False else date.fromordinal(check.toordinal() - 1)
-        elif d < check:
-            break
-
-    return {
-        "total": total,
-        "monthly": monthly,
-        "language_ratio": dict(lang_counts),
-        "top_authors": [{"author": a, "count": c} for a, c in top_authors],
-        "most_read_books": most_read,
-        "streak": streak,
-    }
+    return await get_detail_stats(db, user_id=user.id)

--- a/backend/app/services/book_service.py
+++ b/backend/app/services/book_service.py
@@ -1,0 +1,31 @@
+"""책 관련 공통 서비스 로직."""
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.book import Book
+from app.models.review import Review
+
+
+def review_count_subquery(user_id: int) -> select:
+    """특정 사용자의 리뷰 수를 반환하는 상관 서브쿼리 생성."""
+    return (
+        select(func.count(Review.id))
+        .where(
+            Review.book_id == Book.id,
+            Review.user_id == user_id,
+            Review.is_deleted.is_(False),
+        )
+        .correlate(Book)
+        .scalar_subquery()
+    )
+
+
+async def get_review_count(db: AsyncSession, *, book_id: int, user_id: int) -> int:
+    """특정 책의 리뷰 수를 조회."""
+    stmt = select(func.count(Review.id)).where(
+        Review.book_id == book_id,
+        Review.user_id == user_id,
+        Review.is_deleted.is_(False),
+    )
+    return (await db.execute(stmt)).scalar() or 0

--- a/backend/app/services/search_service.py
+++ b/backend/app/services/search_service.py
@@ -1,0 +1,72 @@
+"""Google Books API 검색 서비스 — 파싱/변환 로직."""
+
+import re
+
+GOOGLE_BOOKS_URL = "https://www.googleapis.com/books/v1/volumes"
+
+# 아동/유아 관련 카테고리 키워드
+CHILDREN_CATEGORIES = {
+    "juvenile",
+    "children",
+    "picture book",
+    "그림책",
+    "유아",
+    "아동",
+    "동화",
+}
+
+_KOREAN_RE = re.compile(r"[\uac00-\ud7af\u3130-\u318f]")
+
+
+def is_children_book(info: dict) -> bool:
+    """카테고리 기반 아동서 여부 판별."""
+    categories = " ".join(info.get("categories", [])).lower()
+    return any(kw in categories for kw in CHILDREN_CATEGORIES)
+
+
+def detect_language(text: str) -> str:
+    """한글 포함 여부로 언어 감지."""
+    return "ko" if _KOREAN_RE.search(text) else "en"
+
+
+def parse_google_book(info: dict, lang: str = "ko") -> dict:
+    """Google Books volumeInfo → BookSearchResult 형태로 변환."""
+    isbn = None
+    for identifier in info.get("industryIdentifiers", []):
+        if identifier["type"] in ("ISBN_13", "ISBN_10"):
+            isbn = identifier["identifier"]
+            break
+    return {
+        "title": info.get("title", ""),
+        "author": ", ".join(info.get("authors", [])),
+        "publisher": info.get("publisher", ""),
+        "cover_url": info.get("imageLinks", {}).get("thumbnail", ""),
+        "isbn": isbn,
+        "language": info.get("language", lang),
+        "is_children": is_children_book(info),
+    }
+
+
+def build_google_books_params(
+    query: str,
+    language: str | None = None,
+    *,
+    max_results: int = 20,
+    api_key: str = "",
+) -> dict[str, str | int]:
+    """Google Books API 요청 파라미터 생성."""
+    lang = language or detect_language(query)
+    params: dict[str, str | int] = {
+        "q": query,
+        "maxResults": max_results,
+        "langRestrict": lang,
+    }
+    if api_key:
+        params["key"] = api_key
+    return params
+
+
+def sort_children_first(results: list[dict], *, limit: int = 15) -> list[dict]:
+    """아동서 우선 정렬 후 limit 개수만큼 반환."""
+    results.sort(key=lambda x: (not x["is_children"],))
+    return results[:limit]

--- a/backend/app/services/stats_service.py
+++ b/backend/app/services/stats_service.py
@@ -1,0 +1,106 @@
+"""통계 계산 서비스."""
+
+from collections import defaultdict
+from datetime import date
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.book import Book
+from app.models.review import Review
+from app.schemas.stats import GardenStats
+
+
+async def get_garden_stats(db: AsyncSession, *, user_id: int) -> GardenStats:
+    """포도밭 통계 (포도알, 포도송이, 나무) 계산."""
+    stmt = select(func.count(Review.id)).where(
+        Review.is_deleted == False,  # noqa: E712
+        Review.user_id == user_id,
+    )
+    total = (await db.execute(stmt)).scalar() or 0
+    return GardenStats(
+        total_reviews=total,
+        grapes=total % 10,
+        bunches=(total // 10) % 10,
+        trees=total // 100,
+    )
+
+
+async def get_detail_stats(db: AsyncSession, *, user_id: int) -> dict:
+    """상세 통계 (월별, 인기 작가, 다독 도서, 언어 비율, 연속 읽기) 계산."""
+    base = select(Review, Book).join(Book, Review.book_id == Book.id).where(Review.is_deleted.is_(False), Review.user_id == user_id)
+    rows = (await db.execute(base)).all()
+
+    total = len(rows)
+    if total == 0:
+        return {
+            "total": 0,
+            "monthly": [],
+            "language_ratio": {},
+            "top_authors": [],
+            "most_read_books": [],
+            "streak": 0,
+        }
+
+    # 월별 권수 (최근 12개월)
+    today = date.today()
+    monthly_counts: dict[str, int] = defaultdict(int)
+    for row in rows:
+        key = row.Review.read_date.strftime("%Y-%m")
+        monthly_counts[key] += 1
+
+    monthly = []
+    for i in range(11, -1, -1):
+        m = today.month - i
+        y = today.year
+        while m <= 0:
+            m += 12
+            y -= 1
+        key = f"{y}-{m:02d}"
+        monthly.append({"month": key, "count": monthly_counts.get(key, 0)})
+
+    # 언어 비율
+    lang_counts: dict[str, int] = defaultdict(int)
+    for row in rows:
+        lang = row.Book.language or "ko"
+        lang_counts[lang] += 1
+
+    # 자주 읽은 작가 Top 5
+    author_counts: dict[str, int] = defaultdict(int)
+    for row in rows:
+        author_counts[row.Book.author] += 1
+    top_authors = sorted(author_counts.items(), key=lambda x: -x[1])[:5]
+
+    # 가장 많이 읽은 책 Top 5
+    book_counts: dict[str, dict] = {}
+    for row in rows:
+        bid = str(row.Book.id)
+        if bid not in book_counts:
+            book_counts[bid] = {
+                "id": bid,
+                "title": row.Book.title,
+                "author": row.Book.author,
+                "count": 0,
+            }
+        book_counts[bid]["count"] += 1
+    most_read = sorted(book_counts.values(), key=lambda x: -x["count"])[:5]
+
+    # 연속 읽기 일수 (현재 스트릭)
+    read_dates = sorted({row.Review.read_date for row in rows}, reverse=True)
+    streak = 0
+    check = today
+    for d in read_dates:
+        if d == check:
+            streak += 1
+            check = date.fromordinal(check.toordinal() - 1)
+        elif d < check:
+            break
+
+    return {
+        "total": total,
+        "monthly": monthly,
+        "language_ratio": dict(lang_counts),
+        "top_authors": [{"author": a, "count": c} for a, c in top_authors],
+        "most_read_books": most_read,
+        "streak": streak,
+    }


### PR DESCRIPTION
## Summary
- `stats_service.py`: 통계 계산 로직 전체 분리 (garden stats, detail stats)
- `search_service.py`: Google Books API 파싱/유틸리티 함수 분리
- `book_service.py`: `review_count` 공통 헬퍼 추출 (4곳 중복 제거)
- `stats.py` 핸들러: 107줄 → 26줄로 슬림화
- 프론트엔드 컴포넌트 분할은 별도 이슈로 분리 예정

## Test plan
- [x] 기존 100개 테스트 전체 통과
- [x] ruff lint/format 통과

close #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)