### PR TITLE
refactor: 대형 페이지 컴포넌트 분할 + pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+        args: ["--maxkb=500"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^backend/
+      - id: ruff-format
+        files: ^backend/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "podo-bookshop"
+name = "podo-bookshelf"
 version = "0.1.0"
 description = "포도책장 - 아이와 함께 읽은 책 리딩 로그"
 requires-python = ">=3.12"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -407,7 +407,7 @@ wheels = [
 ]
 
 [[package]]
-name = "podo-bookshop"
+name = "podo-bookshelf"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [

--- a/frontend/src/components/BookFilters.tsx
+++ b/frontend/src/components/BookFilters.tsx
@@ -1,0 +1,61 @@
+import { Search, X } from "lucide-react";
+import { type RefObject } from "react";
+
+const SORT_OPTIONS = [
+  { value: "recent", label: "최근 읽은 순" },
+  { value: "newest", label: "등록순" },
+  { value: "title", label: "제목순" },
+  { value: "most_read", label: "많이 읽은 순" },
+] as const;
+
+interface BookFiltersProps {
+  query: string;
+  onQueryChange: (value: string) => void;
+  sort: string;
+  onSortChange: (value: string) => void;
+  searchRef?: RefObject<HTMLInputElement | null>;
+}
+
+/** 책장 페이지의 검색 + 정렬 필터 바 */
+export default function BookFilters({
+  query,
+  onQueryChange,
+  sort,
+  onSortChange,
+  searchRef,
+}: BookFiltersProps) {
+  return (
+    <div className="flex gap-2">
+      <div className="relative flex-1">
+        <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-warm-400" />
+        <input
+          ref={searchRef}
+          type="text"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="제목이나 저자로 찾기..."
+          className="w-full rounded-lg border border-warm-200 py-2.5 pl-9 pr-8 text-sm focus:border-grape-400 focus:outline-none"
+        />
+        {query && (
+          <button
+            onClick={() => onQueryChange("")}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-warm-400 hover:text-warm-600"
+          >
+            <X size={16} />
+          </button>
+        )}
+      </div>
+      <select
+        value={sort}
+        onChange={(e) => onSortChange(e.target.value)}
+        className="rounded-lg border border-warm-200 px-3 py-2.5 text-sm text-warm-700 focus:border-grape-400 focus:outline-none"
+      >
+        {SORT_OPTIONS.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/frontend/src/components/BookGrid.tsx
+++ b/frontend/src/components/BookGrid.tsx
@@ -1,0 +1,49 @@
+import type { Book } from "../types";
+
+interface BookGridProps {
+  books: Book[];
+  currentUserId?: string;
+  onBookClick: (bookId: string) => void;
+}
+
+/** 책 카드 그리드 — 책장 페이지에서 사용 */
+export default function BookGrid({ books, currentUserId, onBookClick }: BookGridProps) {
+  return (
+    <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-5">
+      {books.map((book) => (
+        <button
+          key={book.id}
+          onClick={() => onBookClick(book.id)}
+          className="group flex flex-col items-center gap-1.5 rounded-xl p-2 transition-colors hover:bg-grape-50"
+        >
+          {book.cover_url ? (
+            <img
+              src={book.cover_url}
+              alt={book.title}
+              className="aspect-[3/4] w-full rounded-lg object-cover shadow-sm transition-transform group-hover:scale-[1.03]"
+            />
+          ) : (
+            <div className="flex aspect-[3/4] w-full items-center justify-center rounded-lg bg-grape-100 text-3xl shadow-sm">
+              📕
+            </div>
+          )}
+          <p className="line-clamp-2 text-center text-xs font-medium text-warm-800">
+            {book.title}
+          </p>
+          <div className="flex items-center gap-1">
+            {book.review_count > 0 && (
+              <span className="rounded-full bg-grape-100 px-1.5 py-0.5 text-[10px] text-grape-600">
+                {book.review_count}회
+              </span>
+            )}
+            {book.user_id && currentUserId && book.user_id !== currentUserId && (
+              <span className="rounded-full bg-warm-100 px-1.5 py-0.5 text-[10px] text-warm-500">
+                가족
+              </span>
+            )}
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/ReviewForm.tsx
+++ b/frontend/src/components/ReviewForm.tsx
@@ -1,0 +1,62 @@
+import { X } from "lucide-react";
+
+interface TagInputFieldProps {
+  tags: string[];
+  tagInput: string;
+  onTagInputChange: (value: string) => void;
+  onTagKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  onTagBlur: () => void;
+  onRemoveTag: (tag: string) => void;
+  /** 태그 chip 내부 X 아이콘 크기 (기본 12) */
+  iconSize?: number;
+  /** input placeholder (태그 없을 때만 표시) */
+  placeholder?: string;
+  /** input text 크기 class (기본 "text-sm") */
+  textSize?: string;
+  /** 컨테이너 min-height class (기본 "min-h-[46px]") */
+  minHeight?: string;
+}
+
+/** 해시태그 입력 필드 — WriteReviewPage, ReviewDetailPage에서 공유 */
+export default function TagInputField({
+  tags,
+  tagInput,
+  onTagInputChange,
+  onTagKeyDown,
+  onTagBlur,
+  onRemoveTag,
+  iconSize = 12,
+  placeholder = "#태그 입력...",
+  textSize = "text-sm",
+  minHeight = "min-h-[46px]",
+}: TagInputFieldProps) {
+  return (
+    <div className={`flex ${minHeight} flex-wrap items-center gap-1.5 rounded-lg border border-warm-200 px-3 py-2 focus-within:border-grape-400`}>
+      {tags.map((tag) => (
+        <span
+          key={tag}
+          className="flex items-center gap-1 rounded-full bg-grape-100 px-2.5 py-0.5 text-xs font-medium text-grape-700"
+        >
+          #{tag}
+          <button
+            type="button"
+            onClick={() => onRemoveTag(tag)}
+            className="text-grape-400 hover:text-grape-700"
+            aria-label={`태그 ${tag} 제거`}
+          >
+            <X size={iconSize} />
+          </button>
+        </span>
+      ))}
+      <input
+        type="text"
+        value={tagInput}
+        onChange={(e) => onTagInputChange(e.target.value)}
+        onKeyDown={onTagKeyDown}
+        onBlur={onTagBlur}
+        placeholder={tags.length === 0 ? placeholder : ""}
+        className={`min-w-[80px] flex-1 bg-transparent ${textSize} outline-none placeholder:text-warm-300`}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/SearchResults.tsx
+++ b/frontend/src/components/SearchResults.tsx
@@ -1,0 +1,108 @@
+import { getLanguageLabel } from "../utils/language";
+import type { BookSearchResult } from "../types";
+
+interface SearchResultListProps {
+  results: BookSearchResult[];
+  onDetailClick: (book: BookSearchResult) => void;
+  onAddClick: (book: BookSearchResult) => void;
+}
+
+/** 검색 결과 리스트 — SearchPage에서 사용 */
+export function SearchResultList({ results, onDetailClick, onAddClick }: SearchResultListProps) {
+  return (
+    <div className="space-y-2">
+      {results.map((book) => (
+        <div
+          key={book.isbn || `${book.title}-${book.author}`}
+          className="flex w-full gap-3 rounded-lg border border-warm-200 p-3"
+        >
+          {book.cover_url ? (
+            <img src={book.cover_url} alt="" className="h-16 w-12 rounded object-cover" />
+          ) : (
+            <div className="flex h-16 w-12 items-center justify-center rounded bg-grape-100">📕</div>
+          )}
+          <div className="min-w-0 flex-1">
+            <p className="truncate font-semibold text-warm-900">{book.title}</p>
+            <p className="truncate text-xs text-warm-500">{book.author}</p>
+            {book.publisher && <p className="truncate text-xs text-warm-500">{book.publisher}</p>}
+            <div className="mt-2 flex gap-2">
+              <button
+                onClick={() => onDetailClick(book)}
+                className="rounded-full border border-warm-200 px-2.5 py-1 text-xs text-warm-600 hover:border-grape-300 hover:text-grape-600"
+              >
+                상세보기
+              </button>
+              <button
+                onClick={() => onAddClick(book)}
+                className="rounded-full bg-grape-100 px-2.5 py-1 text-xs font-medium text-grape-600 hover:bg-grape-200"
+              >
+                책장에 추가
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface BookDetailModalProps {
+  book: BookSearchResult;
+  onClose: () => void;
+  onAdd: (book: BookSearchResult) => void;
+}
+
+/** 책 상세 모달 — SearchPage에서 사용 */
+export function BookDetailModal({ book, onClose, onAdd }: BookDetailModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+    >
+      <div
+        className="mx-4 w-full max-w-sm rounded-2xl bg-white p-6"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex gap-4">
+          {book.cover_url ? (
+            <img src={book.cover_url} alt="" className="h-36 w-28 shrink-0 rounded-lg object-cover shadow" />
+          ) : (
+            <div className="flex h-36 w-28 shrink-0 items-center justify-center rounded-lg bg-grape-100 text-4xl shadow">📕</div>
+          )}
+          <div className="min-w-0 flex-1">
+            <h2 className="font-bold leading-snug text-warm-900">{book.title}</h2>
+            <p className="mt-1 text-sm text-warm-500">{book.author}</p>
+            {book.publisher && (
+              <p className="mt-1 text-xs text-warm-400">{book.publisher}</p>
+            )}
+            {book.isbn && (
+              <p className="mt-1 text-xs text-warm-400">ISBN: {book.isbn}</p>
+            )}
+            {book.language && (
+              <span className="mt-2 inline-block rounded-full bg-warm-100 px-2 py-0.5 text-xs text-warm-500">
+                {getLanguageLabel(book.language)}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="mt-5 flex gap-3">
+          <button
+            onClick={onClose}
+            className="flex-1 rounded-lg border border-warm-200 py-2.5 text-sm text-warm-600 hover:bg-warm-50"
+          >
+            닫기
+          </button>
+          <button
+            onClick={() => { onAdd(book); onClose(); }}
+            className="flex-1 rounded-lg bg-grape-600 py-2.5 text-sm text-white hover:bg-grape-700"
+          >
+            책장에 추가
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useBookSearch.ts
+++ b/frontend/src/hooks/useBookSearch.ts
@@ -1,0 +1,157 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
+import { searchBooks, searchBookByIsbn } from "../api/search";
+import { getBooks, createBook } from "../api/books";
+import type { Book, BookSearchResult } from "../types";
+
+/** 검색 페이지의 데이터 페칭 + 상태 관리 훅 */
+export function useBookSearch() {
+  const navigate = useNavigate();
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const [query, setQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<BookSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [recentBooks, setRecentBooks] = useState<Book[]>([]);
+  const [scannerOpen, setScannerOpen] = useState(false);
+  const [showManual, setShowManual] = useState(false);
+
+  // 직접 입력 필드
+  const [manualTitle, setManualTitle] = useState("");
+  const [manualAuthor, setManualAuthor] = useState("");
+  const [manualPublisher, setManualPublisher] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [selectedBook, setSelectedBook] = useState<BookSearchResult | null>(null);
+  const [lastAddedBook, setLastAddedBook] = useState<Book | null>(null);
+
+  // 최근 추가한 책 로드
+  useEffect(() => {
+    getBooks({ sort: "newest", limit: 4 }).then(({ items }) => setRecentBooks(items));
+  }, []);
+
+  useEffect(() => {
+    searchInputRef.current?.focus();
+  }, []);
+
+  const handleSearch = async () => {
+    if (!query.trim()) return;
+    setSearching(true);
+    setShowManual(false);
+    try {
+      const results = await searchBooks(query);
+      setSearchResults(results);
+    } catch {
+      toast.error("검색에 실패했어요");
+    } finally {
+      setSearching(false);
+    }
+  };
+
+  const handleAddBook = async (result: BookSearchResult) => {
+    try {
+      const book = await createBook({
+        title: result.title,
+        author: result.author,
+        publisher: result.publisher,
+        isbn: result.isbn,
+        cover_url: result.cover_url || null,
+        language: result.language || "ko",
+        is_children: result.is_children ?? false,
+      });
+      toast.success(`"${result.title}" 책장에 추가!`);
+      setSearchResults([]);
+      setQuery("");
+      setLastAddedBook(book);
+      // 최근 추가 목록 갱신
+      setRecentBooks((prev) => [book, ...prev.filter((b) => b.id !== book.id)].slice(0, 4));
+    } catch {
+      toast.error("추가에 실패했어요");
+    }
+  };
+
+  const handleBarcodeScan = async (isbn: string) => {
+    setScannerOpen(false);
+    try {
+      const result = await searchBookByIsbn(isbn);
+      if (result.source === "local") {
+        toast("이미 책장에 있는 책이에요!", { icon: "📚" });
+      } else {
+        await handleAddBook(result.book);
+      }
+    } catch {
+      toast.error("이 바코드의 책 정보를 찾지 못했어요");
+    }
+  };
+
+  const handleManualAdd = async () => {
+    if (!manualTitle.trim() || !manualAuthor.trim()) {
+      toast.error("제목과 저자를 입력해주세요");
+      return;
+    }
+    setAdding(true);
+    try {
+      const book = await createBook({
+        title: manualTitle.trim(),
+        author: manualAuthor.trim(),
+        publisher: manualPublisher.trim() || "",
+        isbn: null,
+        cover_url: null,
+        language: "ko",
+        is_children: false,
+      });
+      toast.success(`"${book.title}" 책장에 추가!`);
+      setManualTitle("");
+      setManualAuthor("");
+      setManualPublisher("");
+      setShowManual(false);
+      setLastAddedBook(book);
+      setRecentBooks((prev) => [book, ...prev.filter((b) => b.id !== book.id)].slice(0, 4));
+    } catch {
+      toast.error("추가에 실패했어요");
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  return {
+    navigate,
+    searchInputRef,
+
+    // 검색 상태
+    query,
+    setQuery,
+    searchResults,
+    searching,
+    handleSearch,
+
+    // 바코드 스캔
+    scannerOpen,
+    setScannerOpen,
+    handleBarcodeScan,
+
+    // 검색 결과 액션
+    selectedBook,
+    setSelectedBook,
+    handleAddBook,
+
+    // 추가 완료 CTA
+    lastAddedBook,
+    setLastAddedBook,
+
+    // 직접 입력
+    showManual,
+    setShowManual,
+    manualTitle,
+    setManualTitle,
+    manualAuthor,
+    setManualAuthor,
+    manualPublisher,
+    setManualPublisher,
+    adding,
+    handleManualAdd,
+
+    // 최근 추가한 책
+    recentBooks,
+  };
+}

--- a/frontend/src/hooks/useBookshelf.ts
+++ b/frontend/src/hooks/useBookshelf.ts
@@ -1,0 +1,191 @@
+import { useCallback, useDeferredValue, useEffect, useRef, useState } from "react";
+import toast from "react-hot-toast";
+import { getBooks, createBook } from "../api/books";
+import { searchBooks, searchBookByIsbn } from "../api/search";
+import type { Book, BookSearchResult } from "../types";
+
+const PAGE_SIZE = 30;
+
+/** 책장 페이지의 데이터 페칭 + 상태 관리 훅 */
+export function useBookshelf() {
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  const [books, setBooks] = useState<Book[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query); // 검색 디바운스
+  const [sort, setSort] = useState("recent");
+  const [offset, setOffset] = useState(0);
+
+  // 새 책 추가 모달
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [addQuery, setAddQuery] = useState("");
+  const [addResults, setAddResults] = useState<BookSearchResult[]>([]);
+  const [addSearching, setAddSearching] = useState(false);
+  const addSearchRef = useRef<HTMLInputElement>(null);
+  const [scannerOpen, setScannerOpen] = useState(false);
+
+  const loadingRef = useRef(false);
+
+  const fetchBooks = useCallback(
+    async (reset = false) => {
+      if (loadingRef.current) return; // 중복 요청 방지
+      loadingRef.current = true;
+      setLoading(true);
+      try {
+        const newOffset = reset ? 0 : offset;
+        const { items, total: t } = await getBooks({
+          q: deferredQuery || undefined,
+          sort,
+          limit: PAGE_SIZE,
+          offset: newOffset,
+        });
+        if (reset) {
+          setBooks(items);
+          setOffset(items.length);
+        } else {
+          setBooks((prev) => [...prev, ...items]);
+          setOffset(newOffset + items.length);
+        }
+        setTotal(t);
+      } catch {
+        toast.error("책 목록을 불러오지 못했어요");
+      } finally {
+        setLoading(false);
+        loadingRef.current = false;
+      }
+    },
+    [deferredQuery, sort, offset],
+  );
+
+  // 초기 로드 + sort/query 변경 시 리셋
+  useEffect(() => {
+    setOffset(0);
+    const load = async () => {
+      setLoading(true);
+      try {
+        const { items, total: t } = await getBooks({
+          q: deferredQuery || undefined,
+          sort,
+          limit: PAGE_SIZE,
+          offset: 0,
+        });
+        setBooks(items);
+        setOffset(items.length);
+        setTotal(t);
+      } catch {
+        toast.error("책 목록을 불러오지 못했어요");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [sort, deferredQuery]);
+
+  // 페이지 진입 시 검색바 포커스
+  useEffect(() => {
+    searchRef.current?.focus();
+  }, []);
+
+  // 모달 열릴 때 검색바 포커스
+  useEffect(() => {
+    if (showAddModal) {
+      setTimeout(() => addSearchRef.current?.focus(), 100);
+    }
+  }, [showAddModal]);
+
+  const handleAddSearch = async () => {
+    if (!addQuery.trim()) return;
+    setAddSearching(true);
+    try {
+      const results = await searchBooks(addQuery);
+      setAddResults(results);
+    } catch {
+      toast.error("검색에 실패했어요");
+    } finally {
+      setAddSearching(false);
+    }
+  };
+
+  const handleAddBook = async (result: BookSearchResult) => {
+    try {
+      await createBook({
+        title: result.title,
+        author: result.author,
+        publisher: result.publisher,
+        isbn: result.isbn,
+        cover_url: result.cover_url || null,
+        language: result.language || "ko",
+        is_children: result.is_children,
+      });
+      toast.success(`"${result.title}" 책장에 추가!`);
+      setShowAddModal(false);
+      setAddQuery("");
+      setAddResults([]);
+      // 목록 새로고침
+      const { items, total: t } = await getBooks({
+        q: deferredQuery || undefined,
+        sort,
+        limit: PAGE_SIZE,
+        offset: 0,
+      });
+      setBooks(items);
+      setOffset(items.length);
+      setTotal(t);
+    } catch {
+      toast.error("추가에 실패했어요");
+    }
+  };
+
+  const handleBarcodeScan = async (isbn: string) => {
+    setScannerOpen(false);
+    try {
+      const result = await searchBookByIsbn(isbn);
+      if (result.source === "local") {
+        toast("이미 책장에 있는 책이에요!", { icon: "📚" });
+      } else {
+        await handleAddBook(result.book);
+      }
+    } catch {
+      toast.error("이 바코드의 책 정보를 찾지 못했어요");
+    }
+  };
+
+  const closeAddModal = () => {
+    setShowAddModal(false);
+    setAddQuery("");
+    setAddResults([]);
+  };
+
+  const hasMore = offset < total;
+
+  return {
+    // 책 목록 상태
+    books,
+    total,
+    loading,
+    query,
+    setQuery,
+    sort,
+    setSort,
+    hasMore,
+    fetchBooks,
+    searchRef,
+
+    // 새 책 추가 모달 상태
+    showAddModal,
+    setShowAddModal,
+    addQuery,
+    setAddQuery,
+    addResults,
+    addSearching,
+    addSearchRef,
+    scannerOpen,
+    setScannerOpen,
+    handleAddSearch,
+    handleAddBook,
+    handleBarcodeScan,
+    closeAddModal,
+  };
+}

--- a/frontend/src/hooks/useTagInput.ts
+++ b/frontend/src/hooks/useTagInput.ts
@@ -1,0 +1,49 @@
+import { useState } from "react";
+
+/** 해시태그 입력 관리 훅 — WriteReviewPage, ReviewDetailPage에서 공유 */
+export function useTagInput(initialTags: string[] = []) {
+  const [tags, setTags] = useState<string[]>(initialTags);
+  const [tagInput, setTagInput] = useState("");
+
+  const addTag = (raw: string) => {
+    const tag = raw.replace(/^#+/, "").trim().toLowerCase();
+    if (tag && !tags.includes(tag)) {
+      setTags((prev) => [...prev, tag]);
+    }
+    setTagInput("");
+  };
+
+  const removeTag = (tag: string) => {
+    setTags((prev) => prev.filter((t) => t !== tag));
+  };
+
+  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" || e.key === "," || e.key === " ") {
+      e.preventDefault();
+      if (tagInput.trim()) addTag(tagInput);
+    } else if (e.key === "Backspace" && !tagInput && tags.length > 0) {
+      setTags((prev) => prev.slice(0, -1));
+    }
+  };
+
+  /** 미입력 상태의 tagInput까지 flush하여 최종 태그 배열 반환 */
+  const flushTags = (): string[] => {
+    if (tagInput.trim()) {
+      return [...tags, tagInput.replace(/^#+/, "").trim().toLowerCase()].filter(
+        (t, i, a) => t && a.indexOf(t) === i,
+      );
+    }
+    return tags;
+  };
+
+  return {
+    tags,
+    setTags,
+    tagInput,
+    setTagInput,
+    addTag,
+    removeTag,
+    handleTagKeyDown,
+    flushTags,
+  };
+}

--- a/frontend/src/pages/BookshelfPage.tsx
+++ b/frontend/src/pages/BookshelfPage.tsx
@@ -1,170 +1,40 @@
-import { useCallback, useDeferredValue, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Camera, Plus, Search, X } from "lucide-react";
-import toast from "react-hot-toast";
-import { getBooks, createBook } from "../api/books";
-import { searchBooks, searchBookByIsbn } from "../api/search";
 import BarcodeScanner from "../components/BarcodeScanner";
+import BookFilters from "../components/BookFilters";
+import BookGrid from "../components/BookGrid";
 import { useAuth } from "../context/AuthContext";
-import type { Book, BookSearchResult } from "../types";
-
-const SORT_OPTIONS = [
-  { value: "recent", label: "최근 읽은 순" },
-  { value: "newest", label: "등록순" },
-  { value: "title", label: "제목순" },
-  { value: "most_read", label: "많이 읽은 순" },
-] as const;
-
-const PAGE_SIZE = 30;
+import { useBookshelf } from "../hooks/useBookshelf";
 
 export default function BookshelfPage() {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const searchRef = useRef<HTMLInputElement>(null);
 
-  const [books, setBooks] = useState<Book[]>([]);
-  const [total, setTotal] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [query, setQuery] = useState("");
-  const deferredQuery = useDeferredValue(query); // 검색 디바운스
-  const [sort, setSort] = useState("recent");
-  const [offset, setOffset] = useState(0);
-
-  // 새 책 추가 모달
-  const [showAddModal, setShowAddModal] = useState(false);
-  const [addQuery, setAddQuery] = useState("");
-  const [addResults, setAddResults] = useState<BookSearchResult[]>([]);
-  const [addSearching, setAddSearching] = useState(false);
-  const addSearchRef = useRef<HTMLInputElement>(null);
-  const [scannerOpen, setScannerOpen] = useState(false);
-
-  const handleBarcodeScan = async (isbn: string) => {
-    setScannerOpen(false);
-    try {
-      const result = await searchBookByIsbn(isbn);
-      if (result.source === "local") {
-        toast("이미 책장에 있는 책이에요!", { icon: "📚" });
-      } else {
-        await handleAddBook(result.book);
-      }
-    } catch {
-      toast.error("이 바코드의 책 정보를 찾지 못했어요");
-    }
-  };
-
-  const loadingRef = useRef(false);
-
-  const fetchBooks = useCallback(
-    async (reset = false) => {
-      if (loadingRef.current) return; // 중복 요청 방지
-      loadingRef.current = true;
-      setLoading(true);
-      try {
-        const newOffset = reset ? 0 : offset;
-        const { items, total: t } = await getBooks({
-          q: deferredQuery || undefined,
-          sort,
-          limit: PAGE_SIZE,
-          offset: newOffset,
-        });
-        if (reset) {
-          setBooks(items);
-          setOffset(items.length);
-        } else {
-          setBooks((prev) => [...prev, ...items]);
-          setOffset(newOffset + items.length);
-        }
-        setTotal(t);
-      } catch {
-        toast.error("책 목록을 불러오지 못했어요");
-      } finally {
-        setLoading(false);
-        loadingRef.current = false;
-      }
-    },
-    [deferredQuery, sort, offset],
-  );
-
-  // 초기 로드 + sort/query 변경 시 리셋
-  useEffect(() => {
-    setOffset(0);
-    const load = async () => {
-      setLoading(true);
-      try {
-        const { items, total: t } = await getBooks({
-          q: deferredQuery || undefined,
-          sort,
-          limit: PAGE_SIZE,
-          offset: 0,
-        });
-        setBooks(items);
-        setOffset(items.length);
-        setTotal(t);
-      } catch {
-        toast.error("책 목록을 불러오지 못했어요");
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-  }, [sort, deferredQuery]);
-
-  // 페이지 진입 시 검색바 포커스
-  useEffect(() => {
-    searchRef.current?.focus();
-  }, []);
-
-  // 모달 열릴 때 검색바 포커스
-  useEffect(() => {
-    if (showAddModal) {
-      setTimeout(() => addSearchRef.current?.focus(), 100);
-    }
-  }, [showAddModal]);
-
-  const handleAddSearch = async () => {
-    if (!addQuery.trim()) return;
-    setAddSearching(true);
-    try {
-      const results = await searchBooks(addQuery);
-      setAddResults(results);
-    } catch {
-      toast.error("검색에 실패했어요");
-    } finally {
-      setAddSearching(false);
-    }
-  };
-
-  const handleAddBook = async (result: BookSearchResult) => {
-    try {
-      await createBook({
-        title: result.title,
-        author: result.author,
-        publisher: result.publisher,
-        isbn: result.isbn,
-        cover_url: result.cover_url || null,
-        language: result.language || "ko",
-        is_children: result.is_children,
-      });
-      toast.success(`"${result.title}" 책장에 추가!`);
-      setShowAddModal(false);
-      setAddQuery("");
-      setAddResults([]);
-      // 목록 새로고침
-      const { items, total: t } = await getBooks({
-        q: deferredQuery || undefined,
-        sort,
-        limit: PAGE_SIZE,
-        offset: 0,
-      });
-      setBooks(items);
-      setOffset(items.length);
-      setTotal(t);
-    } catch {
-      toast.error("추가에 실패했어요");
-    }
-  };
-
-  const hasMore = offset < total;
+  const {
+    books,
+    total,
+    loading,
+    query,
+    setQuery,
+    sort,
+    setSort,
+    hasMore,
+    fetchBooks,
+    searchRef,
+    showAddModal,
+    setShowAddModal,
+    addQuery,
+    setAddQuery,
+    addResults,
+    addSearching,
+    addSearchRef,
+    scannerOpen,
+    setScannerOpen,
+    handleAddSearch,
+    handleAddBook,
+    handleBarcodeScan,
+    closeAddModal,
+  } = useBookshelf();
 
   return (
     <div className="space-y-4">
@@ -185,38 +55,13 @@ export default function BookshelfPage() {
       </div>
 
       {/* 검색 + 정렬 */}
-      <div className="flex gap-2">
-        <div className="relative flex-1">
-          <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-warm-400" />
-          <input
-            ref={searchRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="제목이나 저자로 찾기..."
-            className="w-full rounded-lg border border-warm-200 py-2.5 pl-9 pr-8 text-sm focus:border-grape-400 focus:outline-none"
-          />
-          {query && (
-            <button
-              onClick={() => setQuery("")}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-warm-400 hover:text-warm-600"
-            >
-              <X size={16} />
-            </button>
-          )}
-        </div>
-        <select
-          value={sort}
-          onChange={(e) => setSort(e.target.value)}
-          className="rounded-lg border border-warm-200 px-3 py-2.5 text-sm text-warm-700 focus:border-grape-400 focus:outline-none"
-        >
-          {SORT_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </div>
+      <BookFilters
+        query={query}
+        onQueryChange={setQuery}
+        sort={sort}
+        onSortChange={setSort}
+        searchRef={searchRef}
+      />
 
       {/* 총 권수 */}
       {!loading && (
@@ -227,42 +72,11 @@ export default function BookshelfPage() {
 
       {/* 책 그리드 */}
       {books.length > 0 ? (
-        <div className="grid grid-cols-3 gap-3 sm:grid-cols-4 lg:grid-cols-5">
-          {books.map((book) => (
-            <button
-              key={book.id}
-              onClick={() => navigate(`/books/${book.id}`)}
-              className="group flex flex-col items-center gap-1.5 rounded-xl p-2 transition-colors hover:bg-grape-50"
-            >
-              {book.cover_url ? (
-                <img
-                  src={book.cover_url}
-                  alt={book.title}
-                  className="aspect-[3/4] w-full rounded-lg object-cover shadow-sm transition-transform group-hover:scale-[1.03]"
-                />
-              ) : (
-                <div className="flex aspect-[3/4] w-full items-center justify-center rounded-lg bg-grape-100 text-3xl shadow-sm">
-                  📕
-                </div>
-              )}
-              <p className="line-clamp-2 text-center text-xs font-medium text-warm-800">
-                {book.title}
-              </p>
-              <div className="flex items-center gap-1">
-                {book.review_count > 0 && (
-                  <span className="rounded-full bg-grape-100 px-1.5 py-0.5 text-[10px] text-grape-600">
-                    {book.review_count}회
-                  </span>
-                )}
-                {book.user_id && user && book.user_id !== user.id && (
-                  <span className="rounded-full bg-warm-100 px-1.5 py-0.5 text-[10px] text-warm-500">
-                    가족
-                  </span>
-                )}
-              </div>
-            </button>
-          ))}
-        </div>
+        <BookGrid
+          books={books}
+          currentUserId={user?.id}
+          onBookClick={(id) => navigate(`/books/${id}`)}
+        />
       ) : !loading ? (
         <div className="flex flex-col items-center gap-3 py-16 text-warm-400">
           <span className="text-4xl">📚</span>
@@ -296,16 +110,12 @@ export default function BookshelfPage() {
 
       {/* 새 책 추가 모달 */}
       {showAddModal && (
-        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center" onClick={() => { setShowAddModal(false); setAddQuery(""); setAddResults([]); }}>
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 sm:items-center" onClick={closeAddModal}>
           <div className="mb-16 flex max-h-[75dvh] w-full max-w-lg flex-col rounded-2xl bg-white p-5 sm:mb-0 sm:p-6" onClick={(e) => e.stopPropagation()}>
             <div className="mb-4 flex items-center justify-between">
               <h2 className="text-lg font-bold text-grape-700">새 책 추가</h2>
               <button
-                onClick={() => {
-                  setShowAddModal(false);
-                  setAddQuery("");
-                  setAddResults([]);
-                }}
+                onClick={closeAddModal}
                 className="text-warm-400 hover:text-warm-600"
               >
                 <X size={20} />

--- a/frontend/src/pages/ReviewDetailPage.tsx
+++ b/frontend/src/pages/ReviewDetailPage.tsx
@@ -1,11 +1,22 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, BookOpen, PenSquare, Pencil, Trash2, X } from "lucide-react";
+import { ArrowLeft, BookOpen, PenSquare, Pencil, Trash2 } from "lucide-react";
 import toast from "react-hot-toast";
 import { getReview, updateReview, deleteReview } from "../api/reviews";
 import api from "../api/client";
 import { getLanguageLabel } from "../utils/language";
+import TagInputField from "../components/ReviewForm";
+import { useTagInput } from "../hooks/useTagInput";
 import type { Review } from "../types";
+
+/** 나이(개월) 포맷팅 */
+function formatAge(months: number) {
+  const y = Math.floor(months / 12);
+  const m = months % 12;
+  if (y > 0 && m > 0) return `${y}세 ${m}개월`;
+  if (y > 0) return `${y}세`;
+  return `${m}개월`;
+}
 
 export default function ReviewDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -14,8 +25,7 @@ export default function ReviewDetailPage() {
   const [editing, setEditing] = useState(false);
   const [memo, setMemo] = useState("");
   const [activity, setActivity] = useState("");
-  const [tags, setTags] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState("");
+  const { tags, setTags, tagInput, setTagInput, addTag, removeTag, handleTagKeyDown, flushTags } = useTagInput();
   const [readDate, setReadDate] = useState("");
   const [childAgeMonths, setChildAgeMonths] = useState<number | null>(null);
   const [childBirthdate, setChildBirthdate] = useState("");
@@ -50,42 +60,11 @@ export default function ReviewDetailPage() {
     api.get<{ child_birthdate?: string }>("/settings").then((r) => {
       if (r.data.child_birthdate) setChildBirthdate(r.data.child_birthdate);
     });
-  }, [id]);
-
-  const formatAge = (months: number) => {
-    const y = Math.floor(months / 12);
-    const m = months % 12;
-    if (y > 0 && m > 0) return `${y}세 ${m}개월`;
-    if (y > 0) return `${y}세`;
-    return `${m}개월`;
-  };
-
-  const addTag = (raw: string) => {
-    const tag = raw.replace(/^#+/, "").trim().toLowerCase();
-    if (tag && !tags.includes(tag)) {
-      setTags((prev) => [...prev, tag]);
-    }
-    setTagInput("");
-  };
-
-  const removeTag = (tag: string) => {
-    setTags((prev) => prev.filter((t) => t !== tag));
-  };
-
-  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" || e.key === "," || e.key === " ") {
-      e.preventDefault();
-      if (tagInput.trim()) addTag(tagInput);
-    } else if (e.key === "Backspace" && !tagInput && tags.length > 0) {
-      setTags((prev) => prev.slice(0, -1));
-    }
-  };
+  }, [id, setTags]);
 
   const handleUpdate = async () => {
     if (!id) return;
-    const finalTags = tagInput.trim()
-      ? [...tags, tagInput.replace(/^#+/, "").trim().toLowerCase()].filter((t, i, a) => t && a.indexOf(t) === i)
-      : tags;
+    const finalTags = flushTags();
     try {
       const updated = await updateReview(id, { memo, activity, tags: finalTags, read_date: readDate, child_age_months: ageMonths });
       setReview({ ...review!, ...updated });
@@ -118,37 +97,8 @@ export default function ReviewDetailPage() {
         <ArrowLeft size={16} /> 돌아가기
       </button>
 
-      <div className="flex gap-4 rounded-xl bg-white p-5 shadow-sm">
-        {review.book?.cover_url ? (
-          <img src={review.book.cover_url} alt="" className="h-32 w-24 rounded-lg object-cover shadow" />
-        ) : (
-          <div className="flex h-32 w-24 items-center justify-center rounded-lg bg-grape-100 text-3xl shadow">📕</div>
-        )}
-        <div className="flex-1">
-          <h1 className="text-lg font-bold text-warm-900">{review.book?.title}</h1>
-          <p className="text-sm text-warm-500">{review.book?.author}</p>
-          {review.book?.publisher && <p className="text-xs text-warm-500">{review.book.publisher}</p>}
-          {review.book?.language && (
-            <span className="mt-1 inline-block rounded-full bg-warm-100 px-2 py-0.5 text-xs text-warm-500">
-              {getLanguageLabel(review.book.language)}
-            </span>
-          )}
-          <div className="mt-2 flex items-center gap-3">
-            <Link
-              to={`/books/${review.book_id}`}
-              className="flex items-center gap-1 text-xs text-grape-500 hover:text-grape-700"
-            >
-              <BookOpen size={12} /> 리딩로그 모아보기
-            </Link>
-            <Link
-              to={`/write?book_id=${review.book_id}`}
-              className="flex items-center gap-1 text-xs text-grape-500 hover:text-grape-700"
-            >
-              <PenSquare size={12} /> 리딩로그 추가
-            </Link>
-          </div>
-        </div>
-      </div>
+      {/* 책 정보 카드 */}
+      <ReviewBookCard review={review} />
 
       <div className="rounded-xl bg-white p-5 shadow-sm">
         <div className="mb-4 flex items-center justify-between">
@@ -207,22 +157,18 @@ export default function ReviewDetailPage() {
             </div>
             <div>
               <label className="text-xs font-medium text-warm-500">해시태그</label>
-              <div className="mt-1 flex min-h-[38px] flex-wrap items-center gap-1.5 rounded-lg border border-warm-200 px-3 py-1.5 focus-within:border-grape-400">
-                {tags.map((tag) => (
-                  <span key={tag} className="flex items-center gap-1 rounded-full bg-grape-100 px-2 py-0.5 text-xs font-medium text-grape-700">
-                    #{tag}
-                    <button type="button" onClick={() => removeTag(tag)} className="text-grape-400 hover:text-grape-700">
-                      <X size={11} />
-                    </button>
-                  </span>
-                ))}
-                <input
-                  type="text" value={tagInput}
-                  onChange={(e) => setTagInput(e.target.value)}
-                  onKeyDown={handleTagKeyDown}
-                  onBlur={() => { if (tagInput.trim()) addTag(tagInput); }}
-                  placeholder={tags.length === 0 ? "#태그..." : ""}
-                  className="min-w-[60px] flex-1 bg-transparent text-xs outline-none placeholder:text-warm-300"
+              <div className="mt-1">
+                <TagInputField
+                  tags={tags}
+                  tagInput={tagInput}
+                  onTagInputChange={setTagInput}
+                  onTagKeyDown={handleTagKeyDown}
+                  onTagBlur={() => { if (tagInput.trim()) addTag(tagInput); }}
+                  onRemoveTag={removeTag}
+                  iconSize={11}
+                  placeholder="#태그..."
+                  textSize="text-xs"
+                  minHeight="min-h-[38px]"
                 />
               </div>
             </div>
@@ -232,78 +178,149 @@ export default function ReviewDetailPage() {
             </div>
           </div>
         ) : (
-          <div className="space-y-4">
-            <div className="flex gap-6">
-              <div>
-                <p className="text-xs font-medium text-warm-500">읽은 날짜</p>
-                <p className="mt-1 text-sm text-warm-900">{review.read_date}</p>
-              </div>
-              {review.child_age_months != null && (
-                <div>
-                  <p className="text-xs font-medium text-warm-500">아이 나이</p>
-                  <p className="mt-1 text-sm text-warm-900">{formatAge(review.child_age_months)}</p>
-                </div>
-              )}
-            </div>
-            {review.memo && (
-              <div>
-                <p className="text-xs font-medium text-warm-500">감상/메모</p>
-                <p className="mt-1 whitespace-pre-wrap text-sm text-warm-900">{review.memo}</p>
-              </div>
-            )}
-            {review.activity && (
-              <div>
-                <p className="text-xs font-medium text-warm-500">활용 내용</p>
-                <p className="mt-1 whitespace-pre-wrap text-sm text-warm-900">{review.activity}</p>
-              </div>
-            )}
-            {review.tags && review.tags.length > 0 && (
-              <div>
-                <p className="text-xs font-medium text-warm-500">해시태그</p>
-                <div className="mt-1.5 flex flex-wrap gap-1.5">
-                  {review.tags.map((tag) => (
-                    <span key={tag} className="rounded-full bg-grape-100 px-2.5 py-0.5 text-xs font-medium text-grape-700">
-                      #{tag}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
+          <ReviewReadView review={review} />
         )}
       </div>
 
       {/* 삭제 확인 모달 */}
       {showDeleteConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-          role="dialog"
-          aria-modal="true"
-          onClick={() => setShowDeleteConfirm(false)}
-          onKeyDown={(e) => { if (e.key === "Escape") setShowDeleteConfirm(false); }}
-        >
-          <div className="mx-4 w-full max-w-sm rounded-2xl bg-white p-6" onClick={(e) => e.stopPropagation()}>
-            <p className="text-center font-medium text-warm-900">
-              이 리딩 로그를 삭제할까요?
-            </p>
-            <div className="mt-5 flex gap-3">
-              <button
-                onClick={() => setShowDeleteConfirm(false)}
-                className="flex-1 rounded-lg border border-warm-200 py-2.5 text-sm text-warm-600 hover:bg-warm-50"
-              >
-                취소
-              </button>
-              <button
-                onClick={handleDelete}
-                disabled={deleting}
-                className="flex-1 rounded-lg bg-red-500 py-2.5 text-sm text-white hover:bg-red-600 disabled:opacity-50"
-              >
-                {deleting ? "삭제 중..." : "삭제"}
-              </button>
-            </div>
+        <DeleteConfirmModal
+          deleting={deleting}
+          onCancel={() => setShowDeleteConfirm(false)}
+          onConfirm={handleDelete}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ── 서브 컴포넌트 ── */
+
+interface ReviewBookCardProps {
+  review: Review;
+}
+
+/** 리뷰 상세 페이지 상단 책 정보 카드 */
+function ReviewBookCard({ review }: ReviewBookCardProps) {
+  return (
+    <div className="flex gap-4 rounded-xl bg-white p-5 shadow-sm">
+      {review.book?.cover_url ? (
+        <img src={review.book.cover_url} alt="" className="h-32 w-24 rounded-lg object-cover shadow" />
+      ) : (
+        <div className="flex h-32 w-24 items-center justify-center rounded-lg bg-grape-100 text-3xl shadow">📕</div>
+      )}
+      <div className="flex-1">
+        <h1 className="text-lg font-bold text-warm-900">{review.book?.title}</h1>
+        <p className="text-sm text-warm-500">{review.book?.author}</p>
+        {review.book?.publisher && <p className="text-xs text-warm-500">{review.book.publisher}</p>}
+        {review.book?.language && (
+          <span className="mt-1 inline-block rounded-full bg-warm-100 px-2 py-0.5 text-xs text-warm-500">
+            {getLanguageLabel(review.book.language)}
+          </span>
+        )}
+        <div className="mt-2 flex items-center gap-3">
+          <Link
+            to={`/books/${review.book_id}`}
+            className="flex items-center gap-1 text-xs text-grape-500 hover:text-grape-700"
+          >
+            <BookOpen size={12} /> 리딩로그 모아보기
+          </Link>
+          <Link
+            to={`/write?book_id=${review.book_id}`}
+            className="flex items-center gap-1 text-xs text-grape-500 hover:text-grape-700"
+          >
+            <PenSquare size={12} /> 리딩로그 추가
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ReviewReadViewProps {
+  review: Review;
+}
+
+/** 리뷰 읽기 전용 뷰 */
+function ReviewReadView({ review }: ReviewReadViewProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-6">
+        <div>
+          <p className="text-xs font-medium text-warm-500">읽은 날짜</p>
+          <p className="mt-1 text-sm text-warm-900">{review.read_date}</p>
+        </div>
+        {review.child_age_months != null && (
+          <div>
+            <p className="text-xs font-medium text-warm-500">아이 나이</p>
+            <p className="mt-1 text-sm text-warm-900">{formatAge(review.child_age_months)}</p>
+          </div>
+        )}
+      </div>
+      {review.memo && (
+        <div>
+          <p className="text-xs font-medium text-warm-500">감상/메모</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm text-warm-900">{review.memo}</p>
+        </div>
+      )}
+      {review.activity && (
+        <div>
+          <p className="text-xs font-medium text-warm-500">활용 내용</p>
+          <p className="mt-1 whitespace-pre-wrap text-sm text-warm-900">{review.activity}</p>
+        </div>
+      )}
+      {review.tags && review.tags.length > 0 && (
+        <div>
+          <p className="text-xs font-medium text-warm-500">해시태그</p>
+          <div className="mt-1.5 flex flex-wrap gap-1.5">
+            {review.tags.map((tag) => (
+              <span key={tag} className="rounded-full bg-grape-100 px-2.5 py-0.5 text-xs font-medium text-grape-700">
+                #{tag}
+              </span>
+            ))}
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+interface DeleteConfirmModalProps {
+  deleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+/** 삭제 확인 모달 */
+function DeleteConfirmModal({ deleting, onCancel, onConfirm }: DeleteConfirmModalProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      role="dialog"
+      aria-modal="true"
+      onClick={onCancel}
+      onKeyDown={(e) => { if (e.key === "Escape") onCancel(); }}
+    >
+      <div className="mx-4 w-full max-w-sm rounded-2xl bg-white p-6" onClick={(e) => e.stopPropagation()}>
+        <p className="text-center font-medium text-warm-900">
+          이 리딩 로그를 삭제할까요?
+        </p>
+        <div className="mt-5 flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-lg border border-warm-200 py-2.5 text-sm text-warm-600 hover:bg-warm-50"
+          >
+            취소
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={deleting}
+            className="flex-1 rounded-lg bg-red-500 py-2.5 text-sm text-white hover:bg-red-600 disabled:opacity-50"
+          >
+            {deleting ? "삭제 중..." : "삭제"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,120 +1,37 @@
-import { useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router-dom";
 import { Camera, PenLine, Search } from "lucide-react";
-import toast from "react-hot-toast";
-import { searchBooks, searchBookByIsbn } from "../api/search";
-import { getBooks, createBook } from "../api/books";
 import BarcodeScanner from "../components/BarcodeScanner";
-import { getLanguageLabel } from "../utils/language";
-import type { Book, BookSearchResult } from "../types";
+import { SearchResultList, BookDetailModal } from "../components/SearchResults";
+import { useBookSearch } from "../hooks/useBookSearch";
 
 export default function SearchPage() {
-  const navigate = useNavigate();
-  const searchInputRef = useRef<HTMLInputElement>(null);
-
-  const [query, setQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<BookSearchResult[]>([]);
-  const [searching, setSearching] = useState(false);
-  const [recentBooks, setRecentBooks] = useState<Book[]>([]);
-  const [scannerOpen, setScannerOpen] = useState(false);
-  const [showManual, setShowManual] = useState(false);
-
-  // 직접 입력 필드
-  const [manualTitle, setManualTitle] = useState("");
-  const [manualAuthor, setManualAuthor] = useState("");
-  const [manualPublisher, setManualPublisher] = useState("");
-  const [adding, setAdding] = useState(false);
-  const [selectedBook, setSelectedBook] = useState<BookSearchResult | null>(null);
-  const [lastAddedBook, setLastAddedBook] = useState<Book | null>(null);
-
-  // 최근 추가한 책 로드
-  useEffect(() => {
-    getBooks({ sort: "newest", limit: 4 }).then(({ items }) => setRecentBooks(items));
-  }, []);
-
-  useEffect(() => {
-    searchInputRef.current?.focus();
-  }, []);
-
-  const handleSearch = async () => {
-    if (!query.trim()) return;
-    setSearching(true);
-    setShowManual(false);
-    try {
-      const results = await searchBooks(query);
-      setSearchResults(results);
-    } catch {
-      toast.error("검색에 실패했어요");
-    } finally {
-      setSearching(false);
-    }
-  };
-
-  const handleAddBook = async (result: BookSearchResult) => {
-    try {
-      const book = await createBook({
-        title: result.title,
-        author: result.author,
-        publisher: result.publisher,
-        isbn: result.isbn,
-        cover_url: result.cover_url || null,
-        language: result.language || "ko",
-        is_children: result.is_children ?? false,
-      });
-      toast.success(`"${result.title}" 책장에 추가!`);
-      setSearchResults([]);
-      setQuery("");
-      setLastAddedBook(book);
-      // 최근 추가 목록 갱신
-      setRecentBooks((prev) => [book, ...prev.filter((b) => b.id !== book.id)].slice(0, 4));
-    } catch {
-      toast.error("추가에 실패했어요");
-    }
-  };
-
-  const handleBarcodeScan = async (isbn: string) => {
-    setScannerOpen(false);
-    try {
-      const result = await searchBookByIsbn(isbn);
-      if (result.source === "local") {
-        toast("이미 책장에 있는 책이에요!", { icon: "📚" });
-      } else {
-        await handleAddBook(result.book);
-      }
-    } catch {
-      toast.error("이 바코드의 책 정보를 찾지 못했어요");
-    }
-  };
-
-  const handleManualAdd = async () => {
-    if (!manualTitle.trim() || !manualAuthor.trim()) {
-      toast.error("제목과 저자를 입력해주세요");
-      return;
-    }
-    setAdding(true);
-    try {
-      const book = await createBook({
-        title: manualTitle.trim(),
-        author: manualAuthor.trim(),
-        publisher: manualPublisher.trim() || "",
-        isbn: null,
-        cover_url: null,
-        language: "ko",
-        is_children: false,
-      });
-      toast.success(`"${book.title}" 책장에 추가!`);
-      setManualTitle("");
-      setManualAuthor("");
-      setManualPublisher("");
-      setShowManual(false);
-      setLastAddedBook(book);
-      setRecentBooks((prev) => [book, ...prev.filter((b) => b.id !== book.id)].slice(0, 4));
-    } catch {
-      toast.error("추가에 실패했어요");
-    } finally {
-      setAdding(false);
-    }
-  };
+  const {
+    navigate,
+    searchInputRef,
+    query,
+    setQuery,
+    searchResults,
+    searching,
+    handleSearch,
+    scannerOpen,
+    setScannerOpen,
+    handleBarcodeScan,
+    selectedBook,
+    setSelectedBook,
+    handleAddBook,
+    lastAddedBook,
+    setLastAddedBook,
+    showManual,
+    setShowManual,
+    manualTitle,
+    setManualTitle,
+    manualAuthor,
+    setManualAuthor,
+    manualPublisher,
+    setManualPublisher,
+    adding,
+    handleManualAdd,
+    recentBooks,
+  } = useBookSearch();
 
   return (
     <div className="space-y-6">
@@ -158,92 +75,20 @@ export default function SearchPage() {
 
       {/* 검색 결과 */}
       {searchResults.length > 0 && (
-        <div className="space-y-2">
-          {searchResults.map((book) => (
-            <div
-              key={book.isbn || `${book.title}-${book.author}`}
-              className="flex w-full gap-3 rounded-lg border border-warm-200 p-3"
-            >
-              {book.cover_url ? (
-                <img src={book.cover_url} alt="" className="h-16 w-12 rounded object-cover" />
-              ) : (
-                <div className="flex h-16 w-12 items-center justify-center rounded bg-grape-100">📕</div>
-              )}
-              <div className="min-w-0 flex-1">
-                <p className="truncate font-semibold text-warm-900">{book.title}</p>
-                <p className="truncate text-xs text-warm-500">{book.author}</p>
-                {book.publisher && <p className="truncate text-xs text-warm-500">{book.publisher}</p>}
-                <div className="mt-2 flex gap-2">
-                  <button
-                    onClick={() => setSelectedBook(book)}
-                    className="rounded-full border border-warm-200 px-2.5 py-1 text-xs text-warm-600 hover:border-grape-300 hover:text-grape-600"
-                  >
-                    상세보기
-                  </button>
-                  <button
-                    onClick={() => handleAddBook(book)}
-                    className="rounded-full bg-grape-100 px-2.5 py-1 text-xs font-medium text-grape-600 hover:bg-grape-200"
-                  >
-                    책장에 추가
-                  </button>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
+        <SearchResultList
+          results={searchResults}
+          onDetailClick={setSelectedBook}
+          onAddClick={handleAddBook}
+        />
       )}
 
       {/* 책 상세 모달 */}
       {selectedBook && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
-          role="dialog"
-          aria-modal="true"
-          onClick={() => setSelectedBook(null)}
-          onKeyDown={(e) => { if (e.key === "Escape") setSelectedBook(null); }}
-        >
-          <div
-            className="mx-4 w-full max-w-sm rounded-2xl bg-white p-6"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex gap-4">
-              {selectedBook.cover_url ? (
-                <img src={selectedBook.cover_url} alt="" className="h-36 w-28 shrink-0 rounded-lg object-cover shadow" />
-              ) : (
-                <div className="flex h-36 w-28 shrink-0 items-center justify-center rounded-lg bg-grape-100 text-4xl shadow">📕</div>
-              )}
-              <div className="min-w-0 flex-1">
-                <h2 className="font-bold leading-snug text-warm-900">{selectedBook.title}</h2>
-                <p className="mt-1 text-sm text-warm-500">{selectedBook.author}</p>
-                {selectedBook.publisher && (
-                  <p className="mt-1 text-xs text-warm-400">{selectedBook.publisher}</p>
-                )}
-                {selectedBook.isbn && (
-                  <p className="mt-1 text-xs text-warm-400">ISBN: {selectedBook.isbn}</p>
-                )}
-                {selectedBook.language && (
-                  <span className="mt-2 inline-block rounded-full bg-warm-100 px-2 py-0.5 text-xs text-warm-500">
-                    {getLanguageLabel(selectedBook.language)}
-                  </span>
-                )}
-              </div>
-            </div>
-            <div className="mt-5 flex gap-3">
-              <button
-                onClick={() => setSelectedBook(null)}
-                className="flex-1 rounded-lg border border-warm-200 py-2.5 text-sm text-warm-600 hover:bg-warm-50"
-              >
-                닫기
-              </button>
-              <button
-                onClick={() => { handleAddBook(selectedBook); setSelectedBook(null); }}
-                className="flex-1 rounded-lg bg-grape-600 py-2.5 text-sm text-white hover:bg-grape-700"
-              >
-                책장에 추가
-              </button>
-            </div>
-          </div>
-        </div>
+        <BookDetailModal
+          book={selectedBook}
+          onClose={() => setSelectedBook(null)}
+          onAdd={handleAddBook}
+        />
       )}
 
       {/* 책 추가 완료 후 CTA */}

--- a/frontend/src/pages/WriteReviewPage.tsx
+++ b/frontend/src/pages/WriteReviewPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import { ArrowLeft, X } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import toast from "react-hot-toast";
 import { getBook } from "../api/books";
 import { createReview } from "../api/reviews";
 import api from "../api/client";
 import MilestoneModal from "../components/MilestoneModal";
+import TagInputField from "../components/ReviewForm";
+import { useTagInput } from "../hooks/useTagInput";
 import type { Book } from "../types";
 
 const MILESTONE_NUMBERS = new Set([10, 20, 30, 50, 100, 200, 300, 500]);
@@ -23,8 +25,7 @@ export default function WriteReviewPage() {
   const [readDate, setReadDate] = useState(new Date().toISOString().split("T")[0]);
   const [memo, setMemo] = useState("");
   const [activity, setActivity] = useState("");
-  const [tags, setTags] = useState<string[]>([]);
-  const [tagInput, setTagInput] = useState("");
+  const { tags, tagInput, setTagInput, addTag, removeTag, handleTagKeyDown, flushTags } = useTagInput();
   const [childAgeYears, setChildAgeYears] = useState("");
   const [childAgeMonths, setChildAgeMonths] = useState("");
   const [ageFormat, setAgeFormat] = useState<AgeFormat>("months");
@@ -38,27 +39,6 @@ export default function WriteReviewPage() {
     const total = parseInt(value) || 0;
     setChildAgeYears(String(Math.floor(total / 12)));
     setChildAgeMonths(String(total % 12));
-  };
-
-  const addTag = (raw: string) => {
-    const tag = raw.replace(/^#+/, "").trim().toLowerCase();
-    if (tag && !tags.includes(tag)) {
-      setTags((prev) => [...prev, tag]);
-    }
-    setTagInput("");
-  };
-
-  const removeTag = (tag: string) => {
-    setTags((prev) => prev.filter((t) => t !== tag));
-  };
-
-  const handleTagKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" || e.key === "," || e.key === " ") {
-      e.preventDefault();
-      if (tagInput.trim()) addTag(tagInput);
-    } else if (e.key === "Backspace" && !tagInput && tags.length > 0) {
-      setTags((prev) => prev.slice(0, -1));
-    }
   };
 
   // book_id 없으면 책장으로
@@ -103,10 +83,7 @@ export default function WriteReviewPage() {
   const handleSubmit = async () => {
     if (!bookId) return;
     setSubmitting(true);
-    // flush any pending tag input
-    const finalTags = tagInput.trim()
-      ? [...tags, tagInput.replace(/^#+/, "").trim().toLowerCase()].filter((t, i, a) => t && a.indexOf(t) === i)
-      : tags;
+    const finalTags = flushTags();
     const ageMonths = childAgeYears || childAgeMonths
       ? (parseInt(childAgeYears || "0") * 12) + parseInt(childAgeMonths || "0")
       : null;
@@ -255,33 +232,14 @@ export default function WriteReviewPage() {
         <div>
           <label className="mb-1 block text-sm font-medium text-warm-700">해시태그 (선택)</label>
           <p className="mb-2 text-xs text-warm-400">기억에 남는 반응, 테마 등을 태그로 남겨보세요. Enter 또는 쉼표로 추가.</p>
-          <div className="flex min-h-[46px] flex-wrap items-center gap-1.5 rounded-lg border border-warm-200 px-3 py-2 focus-within:border-grape-400">
-            {tags.map((tag) => (
-              <span
-                key={tag}
-                className="flex items-center gap-1 rounded-full bg-grape-100 px-2.5 py-0.5 text-xs font-medium text-grape-700"
-              >
-                #{tag}
-                <button
-                  type="button"
-                  onClick={() => removeTag(tag)}
-                  className="text-grape-400 hover:text-grape-700"
-                  aria-label={`태그 ${tag} 제거`}
-                >
-                  <X size={12} />
-                </button>
-              </span>
-            ))}
-            <input
-              type="text"
-              value={tagInput}
-              onChange={(e) => setTagInput(e.target.value)}
-              onKeyDown={handleTagKeyDown}
-              onBlur={() => { if (tagInput.trim()) addTag(tagInput); }}
-              placeholder={tags.length === 0 ? "#태그 입력..." : ""}
-              className="min-w-[80px] flex-1 bg-transparent text-sm outline-none placeholder:text-warm-300"
-            />
-          </div>
+          <TagInputField
+            tags={tags}
+            tagInput={tagInput}
+            onTagInputChange={setTagInput}
+            onTagKeyDown={handleTagKeyDown}
+            onTagBlur={() => { if (tagInput.trim()) addTag(tagInput); }}
+            onRemoveTag={removeTag}
+          />
         </div>
         <button
           onClick={handleSubmit}


### PR DESCRIPTION
## Summary
- BookshelfPage: 384줄 → 194줄 (`useBookshelf` hook + `BookFilters`, `BookGrid` 분리)
- SearchPage: 372줄 → 217줄 (`useBookSearch` hook + `SearchResults` 분리)
- WriteReviewPage/ReviewDetailPage: `useTagInput` 공유 hook 추출
- `ReviewForm` (`TagInputField`) 공유 컴포넌트 생성
- `.pre-commit-config.yaml` 추가 (ruff, trailing-whitespace, large-file-check)
- `pyproject.toml` 프로젝트명 오타 수정 (`podo-bookshop` → `podo-bookshelf`)

## Test plan
- [x] 백엔드 101개 테스트 전체 통과
- [x] ESLint + TypeScript + npm build 통과

close #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)